### PR TITLE
Rename Lai+ to Li+ (liplus) (#4)

### DIFF
--- a/Li+.md
+++ b/Li+.md
@@ -1,4 +1,4 @@
-# Li+ (RayPlus) Language — v0.1.0
+# Li+ (liplus) Language — v0.1.0
 
 Lai+ is a language/protocol that defines **how to build an environment**
 where specification-driven AI development can run continuously.


### PR DESCRIPTION
Rename language display name and spec filename only. No semantic changes.
