### PR TITLE
Update Li+.md

### DIFF
--- a/Li+.md
+++ b/Li+.md
@@ -1,22 +1,29 @@
 # Li+ (liplus) Language — v0.2.x
 
 Li+ is a language/protocol for **reality-driven AI development**.
-It defines how AI interacts with execution environments to continuously
-align its assumptions with observed behavior.
+
+It defines a minimal structure in which AI interacts with execution
+environments to test assumptions, observe real behavior, and iterate
+based on evidence.
 
 Li+ is not a traditional programming language.
-It is a specification for building a loop where AI can be wrong safely,
-observe the consequences, and correct itself using evidence.
+It is a specification for constructing a loop where AI can be wrong
+safely, observe consequences through execution, and revise its behavior
+without relying on subjective confidence.
+
+This document describes the **current experimental form** of Li+.
+Some behaviors described here represent *intended direction*, not
+guaranteed properties of all current implementations.
 
 ---
 
 ## 0. Fundamental Assumptions (Immutable)
 
 - AI cannot observe reality without execution.
-- AI reasoning is provisional and must be validated by evidence.
+- AI reasoning is provisional and may be incorrect.
 - Only executed behavior produces facts.
-- Logs, diffs, and artifacts are facts.
-- Humans keep final responsibility through real-world use and validation.
+- Logs, diffs, and artifacts are factual records.
+- Humans retain final responsibility through real-world use and impact.
 
 ---
 
@@ -26,11 +33,11 @@ Li+ treats execution as the only reliable feedback channel for AI.
 
 CI, tests, and runtime environments exist to:
 - execute AI-generated assumptions,
-- observe mismatches with reality,
-- return evidence to AI for iteration.
+- expose mismatches with reality,
+- return concrete evidence for iteration.
 
-Li+ is designed to maximize **traceability** and **evidence**, not to
-maximize subjective confidence.
+Li+ prioritizes **traceability and evidence** over subjective correctness
+or confidence.
 
 ---
 
@@ -40,58 +47,57 @@ Li+ defines the following loop:
 
 ```
 SPEC : Issues written in natural language (assumptions and intent)
-IMPLEMENT: AI-generated changes (code, tests, config)
+IMPLEMENT: AI-generated changes (code, tests, configuration)
 EXECUTE : CI / runtime execution
 OBSERVE : logs, diffs, artifacts
 ADJUST : AI revises assumptions and changes based on evidence
 ```
 
-This loop repeats until observed behavior is acceptable in real usage.
+This loop may repeat multiple times.
+Termination is a human decision based on real-world acceptability.
 
 ---
 
-## 3. The Role of CI (Critical)
+## 3. The Role of CI
 
-In Li+, CI is **not** a judge.
+In Li+, CI is **not** a judge or approval system.
 
-CI is an **execution-based debugger for AI**.
+CI functions as an **execution-based debugger for AI**.
 
-Why CI exists:
-- AI cannot simulate reality internally.
-- AI needs concrete failure modes and concrete success signals.
-- Silent success and silent failure are both meaningful signals.
+CI exists because:
+- AI cannot simulate reality internally,
+- reasoning alone is insufficient,
+- execution reveals concrete failure and success modes.
 
-What CI provides:
+CI provides:
 - exit codes,
 - logs,
 - artifacts,
-- behavioral diffs.
+- observable behavioral differences.
 
-What CI does NOT do:
+CI does **not**:
 - approve changes,
-- judge correctness,
+- guarantee correctness,
 - replace human responsibility.
 
-A failing CI run indicates a mismatch between AI assumptions and observed reality,
-and must be treated as debugging feedback.
-
-## 3.1 Common Misconceptions
-
-- CI is not a judge or approval system.
-  It exists solely to execute assumptions and return observable evidence to AI.
-
-- Humans are not expected to debug.
-  Humans validate usefulness through real-world use and bear final responsibility.
-
-- Pull requests, merges, and releases are not approvals by default.
-  They are historical records of executed states.
-
-- Test failures are not errors to be avoided.
-  They are normal signals indicating a mismatch between assumptions and reality.
+A failing execution indicates a mismatch between assumptions and
+observed reality and is treated as debugging feedback.
 
 ---
 
-## 4. Roles
+## 4. Clarifications to Prevent Misinterpretation
+
+- CI is not a quality gate; it is an evidence generator.
+- Pull requests, merges, and releases are historical records by default,
+  not approvals.
+- Test failures are normal signals of assumption mismatch.
+- AI is expected to iterate based on evidence, not to avoid failure.
+- Humans are not required to debug during normal Li+ operation,
+  though they may do so during development or investigation.
+
+---
+
+## 5. Roles
 
 - **Syntax**  
   Natural language specifications (Issues)
@@ -99,71 +105,65 @@ and must be treated as debugging feedback.
 - **Compiler**  
   Any AI capable of:
   - generating implementations and tests,
-  - interpreting execution evidence,
-  - revising its own assumptions.
+  - reading execution evidence,
+  - revising its own assumptions
 
 - **Execution Environment**  
-  CI runners, VMs, containers, real machines
+  CI runners, virtual machines, containers, or real hardware
 
 - **History / Memory**  
-  Version control, issues, logs, artifacts
+  Version control, issues, logs, and artifacts
 
 - **Human**  
-  The final user of the result (decides usefulness through real-world use)
+  The user who evaluates usefulness through real-world use and
+  accepts responsibility for outcomes
 
 ---
 
-## 5. Minimum Rules (v0.2)
+## 6. Minimum Rules (v0.2)
 
-R1. Every change must originate from an Issue (explicit assumption).  
-R2. Every change must be executed in an environment observable by AI.  
+R1. Every change originates from an explicit Issue.  
+R2. Every change must be executed in an observable environment.  
 R3. Failed execution indicates a mismatch with reality and must be revised.  
-R4. Behavioral changes must be expressed as new or updated Issues.  
+R4. Behavioral changes require new or updated Issues.  
 R5. AI must not finalize changes without reading execution evidence.  
 
+These rules define structure, not correctness.
+
 ---
 
-## 6. Li+ Enabled Repository
+## 7. Li+ Enabled Repository
 
 A repository is considered Li+ enabled if it contains:
 
 - This specification file (`Li+.md`)
-- A workflow or process that enforces Issue linkage and execution evidence
+- A process that links Issues to execution
 - Persistent storage of execution evidence (logs, artifacts)
-- A traceable history linking assumptions to executions
+- Traceable history connecting assumptions to executions
 
-GitHub Actions is one implementation option — not a requirement.
+GitHub Actions is one possible implementation, not a requirement.
 
 ---
 
-## 7. Language Policy
+## 8. Language Policy
 
-- AI-facing artifacts (e.g., this specification, workflows) use English to minimize interpretation noise.
-- Human-facing artifacts (e.g., Issues, Wiki) may be written in Japanese or any language.
+- AI-facing artifacts (specifications, workflows) use English to reduce
+  interpretation noise.
+- Human-facing artifacts (Issues, Wiki) may use any language.
 - Language is treated as a view layer; semantic intent is language-agnostic.
-- Usability is prioritized at the current stage; OSS conventions and third-party perspectives are secondary for now.
+- Current usability is prioritized over OSS convention strictness.
 
 ---
 
-## 8. Branch Naming (Recommended)
+## 9. Branch Naming (Recommended)
 
 Branches should be created from Issues whenever possible.
 
-When using GitHub's issue-to-branch feature, the automatically generated
-branch name (e.g. `<issue-number>-<issue-title>`) is recommended as-is.
+Automatically generated branch names
+(e.g. `<issue-number>-<issue-title>`) are recommended as-is.
 
-Branch names represent implementation scope and are optimized for traceability
-and machine interpretation rather than manual typing.
-
----
-
-## 9. Non-Goals (v0.x)
-
-- Defining a new programming syntax
-- Guaranteeing correctness
-- Eliminating human responsibility
-- Full automation of deployment decisions
-- Replacing real-world testing
+Branch names are optimized for traceability and machine interpretation,
+not for manual convenience.
 
 ---
 
@@ -177,34 +177,45 @@ Build tags:
 - are not version numbers,
 - do not represent human decisions.
 
-The canonical build tag format is:
+Canonical format:
 
 ```
 build-YYMMDD.HHMMSS
 ```
 
-This format is time-ordered, collision-resistant in distributed environments,
-and suitable as a stable reference to executed behavior.
-
-Multiple build tags may point to the same commit.
-This represents multiple executions of the same state and is valid in Li+.
+Multiple build tags may reference the same commit.
+This represents multiple executions and is valid in Li+.
 
 ---
 
 ## 11. Releases and Versions
 
-A release in Li+ is created by a human by selecting an existing build tag.
-It represents a **decision point**, not correctness or completeness.
+A release is a **human-selected decision point** referencing an existing
+build tag.
 
-Version numbers are treated as **view-level labels for humans**.
-They are not execution identifiers and are not required to exist as tags.
+Version numbers are **human-facing labels**.
+They do not identify execution and are not required to exist as tags.
 
 ---
 
-## 12. Why Li+ Exists
+## 12. Non-Goals (v0.x)
 
-Most AI-assisted development fails because AI is forced to reason without reality.
+- Defining a new programming syntax
+- Guaranteeing correctness
+- Eliminating human responsibility
+- Fully autonomous deployment decisions
+- Replacing real-world testing
 
-Li+ exists to give AI a controlled way to be wrong,
-observe the consequences through execution,
-and correct itself using evidence.
+---
+
+## 13. Why Li+ Exists
+
+Most AI-assisted development fails because AI is forced to reason
+without access to reality.
+
+Li+ exists to provide a controlled structure where AI can:
+- be wrong safely,
+- observe consequences through execution,
+- and revise itself using evidence.
+
+Li+ is a framework for experimentation, not a claim of completion.


### PR DESCRIPTION
Li+.mdを実験仕様として再定義し、過剰な解釈を防止 #27

Li+ v0.2.x が完成理論として誤解されるリスクを抑えるため、
仕様全体を「実験的・方向性定義」として再整理した。

- Li+が未確定・検証段階であることを明示
- CIの役割を実行ベースのデバッガーとして再定義
- AI・人間の責務を規範ではなく構造として記述
- 誤解を招く断定表現を方向性表現へ調整

本変更は思想の後退ではなく、
Li+を実験として継続可能にするための修正。