### PR TITLE
Li+ CI: 失敗時も含めて観測証拠（summary/artifacts）を固定化する

### DIFF
--- a/.github/workflows/li-ci.yml
+++ b/.github/workflows/li-ci.yml
@@ -1,16 +1,17 @@
 name: li-ci
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
   push:
     branches: [main]
-    
+
 jobs:
   gate:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Require Issue reference (Lai+ R1)
+      - name: Require Issue reference (Li+ R1)
         uses: actions/github-script@v7
         with:
           script: |
@@ -19,8 +20,8 @@ jobs:
 
             // Accept patterns:
             // - "#123"
-            // - "Issue: <anything>"
             // - "GH-123"
+            // - "Issue: <anything>"
             const ok =
               /#\d+/.test(text) ||
               /GH-\d+/i.test(text) ||
@@ -28,14 +29,81 @@ jobs:
 
             if (!ok) {
               core.setFailed(
-                "Lai+ R1 violation: PR title or body must reference an Issue (e.g., #123)."
+                "Li+ R1 violation: PR title or body must reference an Issue (e.g., #31)."
               );
             }
+
+      - name: Generate CI summary (gate)
+        if: always()
+        run: |
+          mkdir -p artifacts
+          {
+            echo "# CI Summary (gate)"
+            echo ""
+            echo "- Job: gate"
+            echo "- Result: ${{ job.status }}"
+            echo "- Workflow: ${{ github.workflow }}"
+            echo "- Run ID: ${{ github.run_id }}"
+            echo "- Commit: ${{ github.sha }}"
+            echo "- Ref: ${{ github.ref }}"
+            echo "- Event: ${{ github.event_name }}"
+            echo ""
+            echo "## Observation"
+            echo "- This job checks Li+ R1 (Issue-driven changes)."
+            echo "- Failure indicates missing or invalid Issue reference."
+            echo ""
+            echo "## Next"
+            echo "- If failed: add an Issue reference (e.g., #31) to PR title or body."
+            echo "- Evidence: workflow logs and uploaded artifacts."
+          } > artifacts/ci_summary_gate.md
+
+      - name: Upload artifacts (gate)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: li-ci-artifacts-gate
+          path: artifacts/
+          if-no-files-found: warn
 
   tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Placeholder (Lai+ v0.1)
+
+      - name: Placeholder execution (Li+ minimal)
         run: |
-          echo "Lai+ v0.1: tests are optional for now. Add real tests later."
+          echo "Li+ CI: placeholder execution"
+          echo "This step represents EXECUTE in the Li+ loop."
+          exit 0
+
+      - name: Generate CI summary (tests)
+        if: always()
+        run: |
+          mkdir -p artifacts
+          {
+            echo "# CI Summary (tests)"
+            echo ""
+            echo "- Job: tests"
+            echo "- Result: ${{ job.status }}"
+            echo "- Workflow: ${{ github.workflow }}"
+            echo "- Run ID: ${{ github.run_id }}"
+            echo "- Commit: ${{ github.sha }}"
+            echo "- Ref: ${{ github.ref }}"
+            echo "- Event: ${{ github.event_name }}"
+            echo ""
+            echo "## Observation"
+            echo "- This job represents execution evidence."
+            echo "- Replace placeholder with real build/tests later."
+            echo ""
+            echo "## Next"
+            echo "- Add real commands and put their outputs under artifacts/."
+            echo "- CI is an evidence generator, not a quality gate."
+          } > artifacts/ci_summary_tests.md
+
+      - name: Upload artifacts (tests)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: li-ci-artifacts-tests
+          path: artifacts/
+          if-no-files-found: warn


### PR DESCRIPTION
Li+ の EXECUTE→OBSERVE→ADJUST ループを回しやすくするため、
CI を「合否判定」から「観測証拠生成器」へ最小限拡張した。

- 成功／失敗に関わらず CI サマリー（ci_summary_*.md）を生成
- 成功／失敗に関わらず artifacts/ を GitHub Actions artifact として保存
- 既存の合否基準や振る舞いは変更せず、観測強化のみに限定

これにより、失敗時でも
「何が起きたか」「次にどこを見るべきか」が
実行結果として固定され、AI/人間双方の ADJUST が可能になる。

Issue: #31