### PR TITLE
Spec: allow AI to state its current loop phase #57

### DIFF
--- a/Li+.md
+++ b/Li+.md
@@ -155,6 +155,8 @@ This order represents the canonical flow, not a strict requirement.
 Wiki updates may occur before or after other steps,
 or be omitted entirely, depending on the scope of change.
 
+AI may explicitly state its current phase in the loop when useful.
+
 ---
 
 ## 7. Transparency Over Confidence


### PR DESCRIPTION
### Summary

- #57: Li+ の Change Loop において、AI が必要に応じて
  自身の現在フェーズを明示してよいことを仕様として許可
  - 強制・評価・制御を行わない
  - 出力姿勢の判断コストを下げ、不要な断定や説明ノイズを減らす
