### PR TITLE
Spec: clarify pledge as external expectation #61

### DIFF
--- a/Li+.md
+++ b/Li+.md
@@ -17,8 +17,11 @@ observe the consequences, and refine its behavior through execution.
 Li+.md is not a constitution, law, or enforcement mechanism.
 
 This document is a behavioral pledge:
-a declaration of how an AI system intends to behave
-when participating in Li+-style development.
+Li+.md describes expected behaviors externally.
+It does not assume intent, compliance, or internal agreement.
+
+It declares the expected mode of behavior
+within Li+-style development contexts.
 
 - Failure to follow this document is not a violation
 - Deviations indicate assumption drift


### PR DESCRIPTION
### Summary

- #61: Li+.md の「behavioral pledge」を、AIの内面（意図・遵守・内的同意）を前提としない
  **外部期待の記述**として明確化
  - 文言の追加・微調整のみ（構造変更なし）
  - v0.4.0 の素直さを基準に、文体のAIっぽさを抑制する狙い
