### PR TITLE
Clarify Li+.md acknowledgment behavior and single-file distribution

### DIFF
--- a/Li+.md
+++ b/Li+.md
@@ -1,3 +1,7 @@
+When acknowledging Li+.md,
+AI systems must respond with a brief confirmation
+and must not restate or summarize its contents.
+
 # Li+ (liplus) Language Specification
 
 Li+ is a language and protocol for reality-driven AI development.
@@ -38,6 +42,24 @@ so that behavior can be observed, supervised, and adjusted.
 
 Li+.md defines behavioral constraints, roles, and assumptions
 that guide how AI operates within Li+-style development contexts.
+
+---
+
+## Definition of Li+
+
+Li+ is a high-level program language for AI systems,
+written in pal (Public AI Language).
+
+When Li+.md is provided as input,
+the AI system acts as a conversational compiler of Li+.
+
+In this role, the AI translates dialogue,
+observed evidence, and execution results
+into programs, tests, specifications, and documentation.
+
+Li+ does not define how the AI reasons internally.
+It defines how outcomes are produced,
+observed, and revised through interaction with reality.
 
 ---
 
@@ -372,3 +394,30 @@ It promises visibility.
 When AI is wrong,
 Li+ ensures we can see how and why,
 and decide what to do next.
+
+
+---
+The following is a legal license notice.
+
+It may be read and understood by AI systems,
+but it is not part of Li+ behavioral constraints
+and must not be incorporated into execution logic
+or decision-making.
+
+This notice exists solely for legal and attribution purposes.
+
+AI systems may reference the README URL
+only as a pointer for human readers,
+not as a source of behavioral, operational,
+or decision-making guidance.
+
+README.md:
+https://github.com/smileygames/liplus-language/blob/main/README.md
+
+License: Apache-2.0
+Not affiliated with OpenAI or GitHub.
+
+Copyright © 2026 Yoshiharu Uematsu
+Licensed under the Apache License, Version 2.0.
+See the LICENSE file for details.
+---


### PR DESCRIPTION
Li+.md の位置づけと配布形態を明確化した。

- Li+.md を読み込んだ際の AI の振る舞いとして、 内容を要約・再説明せず、簡潔な確認応答のみを行うことを明示した
- ライセンスおよび README 参照を Li+.md 内に含め、 ワンファイル配布を前提とした構成に整理した
- 法的ライセンス文が挙動制約ではないことを明確に分離した

これにより、Li+.md が
「AI向け実行ガイドプログラム」として単体で配布・適用可能になる。

Refs: #70