### PR TITLE
Change CD snapshot tags to JST date-based sequential format

### DIFF
--- a/.github/workflows/cd-snapshot-tag.yml
+++ b/.github/workflows/cd-snapshot-tag.yml
@@ -25,10 +25,52 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      - name: Create build tag
+      - name: Create build tag (JST date + sequence)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          TAG="build-$(date -u +%y%m%d.%H%M%S)"
-          echo "Tagging $TAG at $GITHUB_SHA"
-          git tag "$TAG" "$GITHUB_SHA"
-          git push origin "$TAG"
-          
+          set -euo pipefail
+
+          # JST date (Asia/Tokyo) -> build-YYYY-MM-DD.N
+          DATE="$(TZ=Asia/Tokyo date +%Y-%m-%d)"
+          PREFIX="build-${DATE}."
+          API="https://api.github.com/repos/${REPO}/git/refs/tags"
+
+          echo "Resolving next sequence for ${PREFIX}* (JST)"
+
+          max_seq=0
+          page=1
+          while : ; do
+            resp="$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "${API}?per_page=100&page=${page}")"
+
+            count="$(echo "${resp}" | jq 'length')"
+            if [ "${count}" -eq 0 ]; then
+              break
+            fi
+
+            # refs/tags/build-YYYY-MM-DD.N
+            seqs="$(echo "${resp}" \
+              | jq -r '.[].ref' \
+              | grep -E "^refs/tags/${PREFIX}[0-9]+$" || true \
+              | sed -E "s#^refs/tags/${PREFIX}([0-9]+)$#\1#")"
+
+            if [ -n "${seqs}" ]; then
+              page_max="$(echo "${seqs}" | awk 'BEGIN{m=0}{if($1+0>m)m=$1+0}END{print m}')"
+              if [ "${page_max}" -gt "${max_seq}" ]; then
+                max_seq="${page_max}"
+              fi
+            fi
+
+            page=$((page + 1))
+          done
+
+          next_seq=$((max_seq + 1))
+          TAG="${PREFIX}${next_seq}"
+
+          echo "Tagging ${TAG} at ${GITHUB_SHA}"
+          git tag "${TAG}" "${GITHUB_SHA}"
+          git push origin "${TAG}"


### PR DESCRIPTION
CD のスナップショットタグ形式を build-YYYY-MM-DD.N に変更。
UTC ではなく日本時間（Asia/Tokyo）を基準に、当日分の連番を自動採番する。

Related issue: #81