### PR TITLE
Fix CD snapshot tag sequence parsing

### DIFF
--- a/.github/workflows/cd-snapshot-tag.yml
+++ b/.github/workflows/cd-snapshot-tag.yml
@@ -52,14 +52,16 @@ jobs:
               break
             fi
 
-            # refs/tags/build-YYYY-MM-DD.N
+            # refs/tags/build-YYYY-MM-DD.N の N だけ抜く（sedを使わない）
             seqs="$(echo "${resp}" \
               | jq -r '.[].ref' \
-              | grep -E "^refs/tags/${PREFIX}[0-9]+$" || true \
-              | sed -E "s#^refs/tags/${PREFIX}([0-9]+)$#\1#")"
+              | grep -E "^refs/tags/${PREFIX}[0-9]+$" || true)"
 
             if [ -n "${seqs}" ]; then
-              page_max="$(echo "${seqs}" | awk 'BEGIN{m=0}{if($1+0>m)m=$1+0}END{print m}')"
+              page_max="$(echo "${seqs}" \
+                | awk -F'.' '{print $NF}' \
+                | awk 'BEGIN{m=0}{if($1+0>m)m=$1+0}END{print m}')"
+
               if [ "${page_max}" -gt "${max_seq}" ]; then
                 max_seq="${page_max}"
               fi


### PR DESCRIPTION
- sed によるタグ番号抽出を廃止し、awk ベースで安全に連番を算出
- build-YYYY-MM-DD.N 形式（JST基準）のタグ生成処理を安定化
- 日付文字列に含まれる記号によるパースエラーを回避

Related issue: #81