### PR TITLE
Add github_rules_page to Project Configuration (Li+)

### DIFF
--- a/Li+.md
+++ b/Li+.md
@@ -332,6 +332,7 @@ Li+Index
 wiki_index_page:
 0.-Liplus_Index
 
----
+github_rules_page:
+https://github.com/smileygames/liplus-language/wiki/E.-github
 
 ---


### PR DESCRIPTION
Li+.md の Project Configuration に github_rules_page を追加した。 GitHub運用ルールは Wiki（E.-github）に集約し、
Li+.md 本体からは URL 参照のみとする構成にした。

Refs #<86>