### PR TITLE
Fix CD snapshot tag generation using git tag list

### DIFF
--- a/.github/workflows/cd-snapshot-tag.yml
+++ b/.github/workflows/cd-snapshot-tag.yml
@@ -24,44 +24,36 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
-      
+
       - name: Create build tag (JST date + sequence)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-      
+
+          # Ensure tags are available locally
+          git fetch --tags --force
+
           # JST date
           DATE="$(TZ=Asia/Tokyo date +%Y-%m-%d)"
           PREFIX="build-${DATE}."
-      
+
           echo "Resolving next sequence for ${PREFIX}* (JST)"
-      
-          # Fetch all tag refs once
-          refs="$(curl -fsSL \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${REPO}/git/refs/tags")"
-      
-          # Extract sequence numbers safely
+
+          # Find max existing sequence number for today's prefix
           max_seq="$(
-            echo "${refs}" \
-              | jq -r '.[].ref' \
-              | grep -E "^refs/tags/${PREFIX}[0-9]+$" || true \
-              | awk -F. '{print $NF}' \
+            git tag -l "${PREFIX}[0-9]*" \
+              | sed -E "s/^${PREFIX}//" \
               | sort -n \
               | tail -1
           )"
-      
-          if [ -z "${max_seq}" ]; then
-            max_seq=0
-          fi
-      
+
+          # Default when no tag exists
+          : "${max_seq:=0}"
+
           next_seq=$((max_seq + 1))
           TAG="${PREFIX}${next_seq}"
-      
-          echo "Tagging ${TAG} at ${GITHUB_SHA}"
-          git tag "${TAG}" "${GITHUB_SHA}"
+
+          echo "Tagging ${TAG} at ${TARGET_SHA}"
+          git tag "${TAG}" "${TARGET_SHA}"
           git push origin "${TAG}"
-    


### PR DESCRIPTION
CD workflow における snapshot tag 生成処理を修正した。
GitHub API / jq 依存を廃し、git tag -l を用いた安定した
シーケンス解決方式に変更している。
また、CI が検証した commit（workflow_run.head_sha）に
確実にタグ付けするようにした。

Refs #<86>