### PR TITLE
Add wiki write workflow (Issue #94)

### DIFF
--- a/.github/workflows/.github/workflows/wiki-write.yml
+++ b/.github/workflows/.github/workflows/wiki-write.yml
@@ -1,0 +1,61 @@
+name: Li+ Wiki Write (Issue #94 Trigger)
+
+on:
+  workflow_dispatch:
+    inputs:
+      wiki_file:
+        description: "Wiki page filename (e.g. today.md)"
+        required: true
+      content_base64:
+        description: "Base64 encoded markdown content"
+        required: true
+      commit_message:
+        description: "Commit message"
+        required: true
+
+  issues:
+    types: [opened, edited]
+
+jobs:
+  wiki-write:
+    # Issue #94 のみを対象にする
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.number == 94 && github.event.issue.state == 'open')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set variables
+        run: |
+          echo "BRANCH_NAME=feature/wiki-actions" >> $GITHUB_ENV
+
+      # Wiki repo を checkout
+      - name: Checkout Wiki repository
+        uses: actions/checkout@v4
+        with:
+          repository: smileygames/liplus-language.wiki
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # サブブランチ作成（既にあればそのまま）
+      - name: Create or switch branch
+        run: |
+          git fetch origin
+          git checkout -B $BRANCH_NAME
+
+      # Wiki ファイル書き込み
+      - name: Write Wiki file
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "${{ inputs.content_base64 }}" | base64 --decode > "${{ inputs.wiki_file }}"
+
+      # commit & push
+      - name: Commit and push
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "Li+ Bot"
+          git config user.email "li-plus@users.noreply.github.com"
+
+          git add .
+          git commit -m "[Li+ Wiki Write] ${{ inputs.commit_message }}" || echo "No changes to commit"
+          git push origin $BRANCH_NAME


### PR DESCRIPTION
GitHub Actions を用いて、AI が Wiki を更新するためのワークフローを追加。

本実装は Issue #94 の設計に基づき、
AI は設計・文章生成のみを行い、git 操作は GitHub Actions が担当する構成とする。

Wiki は人間と AI の共同編集を前提とし、
自動化は常に可逆で、履歴が追跡可能な形に限定している。

背景・思想については以下の Wiki を参照：
https://github.com/smileygames/liplus-language/wiki/C.-Reality_Driven_AI_Development