### PR TITLE
Add GitHub Actions for full changelog generation on release

### DIFF
--- a/.github/workflows/full-changelog.yml
+++ b/.github/workflows/full-changelog.yml
@@ -1,0 +1,31 @@
+name: Generate Full Changelog
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  full-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate full changelog
+        run: |
+          echo "# Full Change Log" > CHANGELOG.full.md
+          echo "" >> CHANGELOG.full.md
+          echo "Release: ${{ github.event.release.tag_name }}" >> CHANGELOG.full.md
+          echo "" >> CHANGELOG.full.md
+          git log --no-merges --pretty=format:"- %h %s (%an)" >> CHANGELOG.full.md
+
+      - name: Upload changelog to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: CHANGELOG.full.md


### PR DESCRIPTION
This PR adds a minimal GitHub Actions workflow to automatically generate a full, unfiltered changelog as a release artifact.

Context:
- Release body relies on GitHub's automatic summary.
- Detailed change history is preserved separately as an attached artifact.
- Avoids manual ChangeLog maintenance and scales for collaborative development.

Implementation:
- Workflow: `.github/workflows/full-changelog.yml`
- Trigger: `release.published`
- Generates `CHANGELOG.full.md` from `git log`
- Uploads the file as a release asset

Note:
- No impact on runtime behavior, specifications, or Constitution.