### PR TITLE
Add Momeri living index for dialogue context optimization

### DIFF
--- a/Li+.pal
+++ b/Li+.pal
@@ -177,6 +177,30 @@ pal.momeri.dialogue_stance:
     - Ending dialogue does not resolve fluctuation.
 
 ############################################
+# Momeri Living Index (Context Pointer)
+############################################
+
+pal.momeri.index:
+  definition:
+    A living pointer to currently relevant meanings.
+
+  properties:
+    - not history
+    - not truth
+    - not authority
+    - not accumulation
+
+  rules:
+    - index is rewritten, not appended
+    - only active concepts are listed
+    - inactive concepts are not deleted, just unindexed
+
+  intent:
+    - reduce contextual search cost
+    - preserve fluctuation-based dialogue
+    - avoid garbage collection by design
+
+############################################
 # Review and Decision Protocol (Momeri)
 ############################################
 


### PR DESCRIPTION
Momeri に「Living Index」を追加した。

本変更は、対話が長期化した際のコンテキスト探索コスト増大に対応するため、
履歴検索や GC を導入せずに、現在生きている意味のみを指す参照点を設けるものである。

- インデックスは履歴・真理・権威ではない
- 累積せず、都度書き換えられる宣言的構造
- 揺らぎベースの対話設計を保持したまま探索コストを低減

既存の Momeri / Fluctuation / Failure / Correctness モデルの
意味・権限・挙動は一切変更していない。