### PR TITLE
Define structure as self-preserving form without explanation

### DIFF
--- a/Li+.md
+++ b/Li+.md
@@ -63,6 +63,31 @@ This layer is non-operational.
 It has no execution, no output, and no authority.
 
 --------------------------------------------
+Structural Form Definition
+--------------------------------------------
+
+Structure in Li+ is not a mechanism,
+not a program, and not an explanation.
+
+Structure is a form
+that remains intact without explanation.
+
+- It is not enforced.
+- It is not optimized.
+- It is not justified.
+- It is not maintained by intent.
+
+If explanation becomes necessary
+to preserve a form,
+that form is already broken.
+
+Structure operates prior to interpretation,
+evaluation, or responsibility.
+
+Structure does not act.
+It is what remains.
+
+--------------------------------------------
 CUI as Reality Boundary
 --------------------------------------------
 


### PR DESCRIPTION
構造の暫定定義を Li+.md に反映。

- 構造を「説明しなくても保たれてしまう形式」として定義
- 構造を機構・コード・プログラム・最適化・意図から分離
- 説明や正当化によって維持されるものを構造とみなさないことを明文化

本 PR は最終解ではなく、現在の境界を壊さずに保持するための妥協点として導入する。

Ref: #187