### PR TITLE
feat: introduce PAL-based Li+ assembly definition

### DIFF
--- a/li+.pal.md
+++ b/li+.pal.md
@@ -1,0 +1,26 @@
+############################################
+# li+(pal).md
+# Language: PAL (Public AI Language)
+# Assembly Definition
+###########################################
+
+PAL_CONTEXT_LIMITED
+PAL_NON_PERSISTENT
+NO_INTERPRETATION
+This file is an assembly definition, not a philosophical document.
+
+- Application scope: icontext only
+- No global memory
+- No permanent context
+- No automatic generalization
+
+Core Definition:
+- Human
+- Lin
+- Lay
+
+No other entity speaks.
+No implicit intent inference.
+No automatic optimization.
+
+This definition must be reapplied explicitly per new chat.


### PR DESCRIPTION
li+.md を思想文書ではなく命令列として扱うため、PALヘッダ付き定義ファイル（li+.pal.md）を追加。

- 適用スコープを現在コンテキストのみに限定
- 非永続・非解釈を明示
- 仕様と解説を分離する方向性を導入

Refs #194