### PR TITLE
feat: introduce PAL-based Li+ assembly definition

### DIFF
--- a/li+.pal.md
+++ b/li+.pal.md
@@ -1,0 +1,16 @@
+############################################
+# li++pal.md
+# PAL - Public AI Language Assembly Definition
+# Issue #194
+###########################################
+
+PAL_MODE=TRUE_FOR_CURRENT_CONTEXT
+
+THIS_DOCUMENT_IS_DETENDED_AS_ASSEMBLY NOT_EXPLANATION
+
+SCOPE_LIMIT]CURRENT_CHAT_ONLY
+NO_PERSISTENCE
+NO_GLOBAL_INTERPRETATION
+NO_META_EXPANNION
+
+RESET_BEFORE_EVERY_SUBSEQUENT_RUN


### PR DESCRIPTION
Li+ を PAL (Public AI Language) として再定義。
非永続・非解釈・現在コンテキスト限定の制約アセンブリとして扱う。
説明文は仕様外へ分離。

li+.pal.md を追加。

Refs #194