### PR TITLE
Add session initialization hook to install GitHub CLI

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install gh CLI if not already present
+if ! command -v gh &>/dev/null; then
+  echo "Installing gh CLI..."
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+  chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+  apt-get update -q
+  apt-get install -y gh
+  echo "gh CLI installed: $(gh --version | head -1)"
+else
+  echo "gh CLI already installed: $(gh --version | head -1)"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a Claude session initialization hook that automatically installs the GitHub CLI (`gh`) when working in remote code environments.

## Key Changes
- **Added `.claude/hooks/session-start.sh`**: A bash script that conditionally installs the GitHub CLI tool
  - Only runs when `CLAUDE_CODE_REMOTE` environment variable is set to `true`
  - Checks if `gh` is already installed before attempting installation
  - Installs `gh` via the official GitHub CLI Debian package repository
  - Outputs version information for verification

- **Added `.claude/settings.json`**: Configuration file that registers the session start hook
  - Defines a `SessionStart` hook that executes the installation script
  - Integrates with Claude's hook system for automatic execution

## Implementation Details
- The script uses `set -euo pipefail` for safe bash execution
- Installation is skipped if `gh` is already present, avoiding redundant operations
- Uses official GitHub CLI package sources with GPG key verification for security
- Gracefully exits if not in a remote code environment

https://claude.ai/code/session_01DyhLjArMc5zDrAbA8uXnjH