### PR TITLE
docs: add branch creation timing and assignee rules to github wiki

### DIFF
--- a/wiki/E.-github_rules_page.md
+++ b/wiki/E.-github_rules_page.md
@@ -78,8 +78,6 @@ gh api repos/{owner}/{repo}/issues/{issue_number}/assignees \
 
 Add placement rules to Li+ index
 
-------------------------------------------------------------------------
-
 ### Body（必須）
 
 -   **日本語**


### PR DESCRIPTION
ブランチ作成タイミング・命名規則・作業開始時のAssigneeルールをwikiに追記。
着手直前にブランチ作成し、同時にliplus-lin-layをAssigneeに設定するフローを明文化した。
禁止事項にも対応する項目を追加。

Refs #319