### PR TITLE
fix: prevent backtick command execution in CI body validation

### DIFF
--- a/.github/workflows/liplus-ci.yml
+++ b/.github/workflows/liplus-ci.yml
@@ -17,10 +17,11 @@ jobs:
 
       - name: Validate Commit Message
         if: github.event_name == 'push'
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          MESSAGE="${{ github.event.head_commit.message }}"
-          TITLE=$(echo "$MESSAGE" | head -n1)
-          BODY=$(echo "$MESSAGE" | tail -n +2)
+          TITLE=$(echo "$COMMIT_MESSAGE" | head -n1)
+          BODY=$(echo "$COMMIT_MESSAGE" | tail -n +2)
 
           # ASCII title
           if echo "$TITLE" | grep -P '[^\x00-\x7F]' ; then
@@ -43,24 +44,24 @@ jobs:
 
       - name: Validate Pull Request
         if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          BODY="${{ github.event.pull_request.body }}"
-
           # ASCII title
-          if echo "$TITLE" | grep -P '[^\x00-\x7F]' ; then
+          if echo "$PR_TITLE" | grep -P '[^\x00-\x7F]' ; then
             echo "PR title must be ASCII."
             exit 1
           fi
 
           # Japanese body
-          if ! echo "$BODY" | grep -P '[ぁ-んァ-ン一-龥]' ; then
+          if ! echo "$PR_BODY" | grep -P '[ぁ-んァ-ン一-龥]' ; then
             echo "PR body must contain Japanese."
             exit 1
           fi
 
           # Issue reference
-          if ! echo "$BODY" | grep -E '#[0-9]+' ; then
+          if ! echo "$PR_BODY" | grep -E '#[0-9]+' ; then
             echo "PR body must reference issue number."
             exit 1
           fi
@@ -68,18 +69,19 @@ jobs:
 
       - name: Validate Issue
         if: github.event_name == 'issues'
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          TITLE="${{ github.event.issue.title }}"
-          BODY="${{ github.event.issue.body }}"
-
           # ASCII title
-          if echo "$TITLE" | grep -P '[^\x00-\x7F]' ; then
+          if echo "$ISSUE_TITLE" | grep -P '[^\x00-\x7F]' ; then
             echo "Issue title must be ASCII."
             exit 1
           fi
 
           # Japanese body
-          if ! echo "$BODY" | grep -P '[ぁ-んァ-ン一-龥]' ; then
+          if ! echo "$ISSUE_BODY" | grep -P '[ぁ-んァ-ン一-龥]' ; then
             echo "Issue body must contain Japanese."
             exit 1
           fi
+


### PR DESCRIPTION
CI検証スクリプトでのバッククォートによるコマンド実行問題を修正した。各ステップに env: ブロックを追加し、GitHub Actionsの値を環境変数経由で安全に渡すよう変更した。

詳細は #314 を参照。