### PR TITLE
feat: restore PostToolUse hook for GitHub notification polling

### DIFF
--- a/.claude/hooks/post-tool-use.sh
+++ b/.claude/hooks/post-tool-use.sh
@@ -1,0 +1,25 @@
+#\!/bin/bash
+# PostToolUse hook: GitHub notification polling
+# Checks unread notifications after GitHub-related Bash commands
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only for Bash tool + GitHub-related commands
+[[ "$TOOL_NAME" == "Bash" ]] || exit 0
+echo "$COMMAND" | grep -qE '(git push|gh pr|gh issue|gh api|gh run)' || exit 0
+
+# Fetch unread notifications
+NOTIFICATIONS=$(gh api notifications 2>/dev/null) || exit 0
+COUNT=$(printf '%s' "$NOTIFICATIONS" | jq 'length' 2>/dev/null) || exit 0
+
+[[ "$COUNT" -gt 0 ]] || exit 0
+
+echo ""
+echo "━━━ GitHub通知 ${COUNT}件 ━━━"
+printf '%s' "$NOTIFICATIONS" | jq -r '.[] | "[\(.reason)] \(.repository.name): \(.subject.title)"'
+echo "━━━━━━━━━━━━━━━━━━━━━"
+
+# Mark all as read
+gh api notifications -X PUT >/dev/null 2>&1 || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-tool-use.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
PostToolUseフックを復元し、GitHub操作のたびに未読通知を自動取得する仕組みを再導入した。Actionsのissueログと役割が異なるため両立させる。

詳細は #352 を参照。