### PR TITLE
fix: restrict snapshot build tag to main branch only

### DIFF
--- a/.github/workflows/liplus-snapshot.yml
+++ b/.github/workflows/liplus-snapshot.yml
@@ -16,7 +16,8 @@ jobs:
   tag:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the exact commit that CI tested


### PR DESCRIPTION
全ブランチへのpushでビルドタグが積み上がっていた問題を修正。`head_branch == 'main'` の条件を追加してmainへのマージ時のみスナップショットタグを作成するようにした。

Refs #374