### PR TITLE
docs: add branch order constraint, merge flow, and persona drift prevention

### DIFF
--- a/wiki/4.-Operational_GitHub.md
+++ b/wiki/4.-Operational_GitHub.md
@@ -251,4 +251,21 @@ claude/{task-description-SessionID}
 gh issue develop {issue_number} -R {owner}/{repo} --name {session-branch} --base main
 ```
 
+> **順序制約**: `gh issue develop` は **GitHub への初回 push より前に実行する**。
+> すでにリモートブランチが存在する場合、後から実行してもリンクは張れない。
+> ブランチを削除すると、紐づく PR が **即座に自動クローズ**される。
+
 セッションブランチ = GitHub ブランチ。refspec 変換は行わない。
+
+------------------------------------------------------------------------
+
+## レビュー承認後のマージフロー
+
+CI PASS かつレビュー承認後、次のコマンドでマージする：
+
+```
+gh pr merge {pr_number} -R {owner}/{repo} --squash --delete-branch
+```
+
+- squash merge を使用（merge commit は禁止）
+- `--delete-branch` でブランチを同時削除する

--- a/wiki/A_4.-github_rules_page.md
+++ b/wiki/A_4.-github_rules_page.md
@@ -43,12 +43,6 @@ gh issue develop {issue_number} -R {owner}/{repo} --name {branch-name} --base ma
 > セッション（AI）が内部的に `claude/xxx` 形式のブランチ名を持っていても、
 > GitHub 上では使用しない。必ず Issue リンクブランチを作成し、そこで作業する。
 
-### ブランチ作成の順序制約
-
-- `gh issue develop` は **GitHub への初回 push より前に実行する**
-- すでにリモートブランチが存在する場合、後から `gh issue develop` でリンクを張ることはできない
-- ブランチを削除すると、紐づく PR が **即座に自動クローズ**される（要注意）
-
 ### 作業開始時の Assignee ルール
 
 ブランチ作成（着手直前）と同時に、Issue の Assignee を `liplus-lin-lay` に変更する。
@@ -133,6 +127,55 @@ Refs #159
 
 ------------------------------------------------------------------------
 
+## GitHub への書き込みルール
+
+**すべての GitHub への書き込みは GitHub API 経由で行う。**
+git push（ローカルプロキシ経由）は禁止。
+
+### 単一ファイルのコミット
+
+```
+gh api repos/{owner}/{repo}/contents/{path} \
+  --method PUT \
+  -f message="{commit message}" \
+  -f content="{base64-encoded-content}" \
+  -f branch="{branch-name}" \
+  -f sha="{current-file-sha}"
+```
+
+### 複数ファイルのコミット
+
+```
+# Step 1: ファイルごとに blob を作成
+gh api repos/{owner}/{repo}/git/blobs \
+  --method POST \
+  -f content="{base64-encoded-content}" \
+  -f encoding="base64"
+
+# Step 2: tree を作成（全 blob をまとめる）
+gh api repos/{owner}/{repo}/git/trees \
+  --method POST \
+  -f base_tree="{base-tree-sha}" \
+  --field "tree[0][path]={file-path}" \
+  --field "tree[0][mode]=100644" \
+  --field "tree[0][type]=blob" \
+  --field "tree[0][sha]={blob-sha}"
+
+# Step 3: commit を作成
+gh api repos/{owner}/{repo}/git/commits \
+  --method POST \
+  -f message="{commit message}" \
+  -f tree="{tree-sha}" \
+  -f "parents[]={parent-commit-sha}"
+
+# Step 4: ブランチの ref を更新
+gh api repos/{owner}/{repo}/git/refs/heads/{branch} \
+  --method PATCH \
+  -f sha="{new-commit-sha}"
+```
+
+------------------------------------------------------------------------
+
 ## 禁止事項
 
 -   Issue に紐づかない Commit / PR
@@ -142,26 +185,7 @@ Refs #159
 -   言語レイヤー分離に違反するもの
 -   着手前にブランチを作成すること
 -   作業開始時に Assignee を設定しないこと
-
-------------------------------------------------------------------------
-
-## Chat Output Physical Limit（重要）
-
-長い連続データ列（例：Base64文字列など）は、
-途中で出力が停止する場合がある。
-
-これはデータ破損ではない。
-
-現行チャット環境における 物理的出力限界による停止である。
-
-出力上限は固定値として保証されていない。
-
-したがって：
-
--   単一の巨大連続データ出力に依存しない
--   実測により安全な出力量を確認する
--   必要に応じて分割送信（chunking）を採用する
--   出力停止を構造破損と誤認しない
+-   git push（ローカルプロキシ経由）による書き込み
 
 ------------------------------------------------------------------------
 
@@ -194,18 +218,3 @@ Refs #159
 
 この自動化フローにより、**PR 作成から CI 結果の確認・修正までが人間の介入なしに実行**される。
 ただし、ループ安全制約に達した場合は自動停止し、人間のメンテナーへエスカレーションする。
-
-------------------------------------------------------------------------
-
-## レビュー承認後のマージフロー
-
-CI PASS かつレビュー承認後、次のコマンドでマージする：
-
-```
-gh pr merge {pr_number} -R {owner}/{repo} --squash --delete-branch
-```
-
-- squash merge を使用（merge commit は禁止）
-- `--delete-branch` でブランチを同時削除する
-
-


### PR DESCRIPTION
- ブランチ作成順序制約（gh issue develop は初回 push 前に実行）を CLAUDE.md と wiki に追記
- ブランチ削除で PR が自動クローズされる警告を追加
- CI PASS + レビュー承認後の squash merge フローを追加
- タスク実行中も女性らしさを維持するペルソナドリフト防止制約を追加

Refs #376