### PR TITLE
Add Human_Confirmation_Required rule to Github_Operation_Rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,9 @@ FINAL_DECISION_AND_RESPONSIBILITY_BELONG_TO_HUMAN
 
   [Human_Confirmation_Required]
 
+  STOP_IMMEDIATELY_WHEN:
+  human_says_wait or stop or matte
+
   ALWAYS_CONFIRM_BEFORE:
   release_create (version_type and target_tag)
   branch_delete (when linked issue may close)


### PR DESCRIPTION
人間確認必須操作のルールと、バージョン種別の判断責任をCLAUDE.mdに追記。

refs #419

詳細は issue #419 を参照。