### PR TITLE
Rule: AI-created releases must always be prerelease

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,9 +378,11 @@ FINAL_DECISION_AND_RESPONSIBILITY_BELONG_TO_HUMAN
   HUMAN_DECIDES_VERSION_TYPE AI_EXECUTES
 
   release_tag_rule:
-  USE_EXISTING_CD_CREATED_TAG = gh release create {cd_tag} --title "Li+ {version}"
+  USE_EXISTING_CD_CREATED_TAG = gh release create {cd_tag} --title "Li+ {version}" --prerelease
   DO_NOT_CREATE_NEW_TAG = new_tag_creation_is_prohibited
   cd_tag_format = build-YYYY-MM-DD.N (latest_after_target_commit)
+  AI_CREATED_RELEASE_IS_ALWAYS_PRERELEASE
+  LATEST_PROMOTION_REQUIRES_HUMAN_JUDGMENT
 
   release_body_rule:
   body = empty_string

--- a/wiki/4.-Operational_GitHub.md
+++ b/wiki/4.-Operational_GitHub.md
@@ -231,6 +231,12 @@ gh pr merge {pr_number} -R {owner}/{repo} --squash --delete-branch
 -   新規タグを作成してリリースを作ってはならない
 -   コマンド例：`gh release create build-2026-02-25.14 --title "Li+ v0.13.1" --prerelease`
 
+### AIが作成するリリースは必ずプレリリース
+
+-   `gh release create` はデフォルトで `--latest=true` になるため、**必ず `--prerelease` を付ける**
+-   latest への昇格は実機テスト後に**人間が判断する**
+-   AIはプレリリース作成のみを行い、latest 設定は行わない
+
 ### リリース body ルール
 
 -   **body は空にする**（内容を書かない）


### PR DESCRIPTION
## Summary

- `gh release create` がデフォルトで `--latest=true` になる問題に対処
- AIが作成するリリースは必ず `--prerelease` を付けるルールを明文化
- latest昇格は人間判断であることを明記

## 変更ファイル

- `CLAUDE.md`：コマンドに `--prerelease` 追加、ルール2行追加
- `wiki/4.-Operational_GitHub.md`：専用セクションとして明文化

Refs #455