### PR TITLE
ci: add branches filter to snapshot workflow_run trigger

### DIFF
--- a/.github/workflows/liplus-snapshot.yml
+++ b/.github/workflows/liplus-snapshot.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["Liplus Governance CI"]
     types: [completed]
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
Refs #503

`workflow_run`トリガーに`branches: [main]`を追加。
main以外のCI完了時はsnapshotワークフロー自体が起動しなくなる。