### PR TITLE
fix: include replies in Discussions agent conversation history

### DIFF
--- a/.github/scripts/liplus_discussions_agent.py
+++ b/.github/scripts/liplus_discussions_agent.py
@@ -53,6 +53,13 @@ def get_discussion() -> dict:
                   body
                   isMinimized
                   author { login }
+                  replies(first: 50) {
+                    nodes {
+                      body
+                      isMinimized
+                      author { login }
+                    }
+                  }
                 }
               }
             }
@@ -139,6 +146,13 @@ for comment in discussion["comments"]["nodes"]:
     login = (comment.get("author") or {}).get("login", "")
     role = "assistant" if login in BOT_LOGINS else "user"
     raw.append((role, comment["body"]))
+    # Flatten replies directly after the comment
+    for reply in comment.get("replies", {}).get("nodes", []):
+        if reply.get("isMinimized"):
+            continue
+        reply_login = (reply.get("author") or {}).get("login", "")
+        reply_role = "assistant" if reply_login in BOT_LOGINS else "user"
+        raw.append((reply_role, reply["body"]))
 
 merged = []
 for role, content in raw:


### PR DESCRIPTION
Refs #516

GraphQLクエリにrepliesを追加し、会話履歴にコメントへの返信もフラット展開するよう修正。
返信で発火した際もコンテキストを正しく把握できるようになる。