### PR TITLE
fix: reply to top-level comment as thread reply in Discussions agent

### DIFF
--- a/.github/scripts/liplus_discussions_agent.py
+++ b/.github/scripts/liplus_discussions_agent.py
@@ -171,6 +171,9 @@ for comment in discussion["comments"]["nodes"]:
         # If this reply triggered the event, reply back in the same thread
         if COMMENT_NODE_ID and reply.get("id") == COMMENT_NODE_ID:
             reply_to_id = comment["id"]
+    # If this top-level comment triggered the event, reply in its thread
+    if COMMENT_NODE_ID and comment.get("id") == COMMENT_NODE_ID:
+        reply_to_id = comment["id"]
 
 merged = []
 for role, content in raw:


### PR DESCRIPTION
Refs #521

トップレベルコメントへの返信時も `reply_to_id` にセットするよう3行追加。
discussion:created（COMMENT_NODE_IDが空）のみトップレベル投稿、それ以外はすべてスレッド内リプライになる。