### PR TITLE
fix: require CI checks pass before merge in PR agent

### DIFF
--- a/.github/scripts/liplus_pr_agent.py
+++ b/.github/scripts/liplus_pr_agent.py
@@ -252,26 +252,11 @@ def parse_fixes(reply: str) -> tuple[list[tuple[str, str, str]], str]:
 
 
 def all_ci_passed(head_sha: str) -> bool:
-    """Check current check-run state on head_sha.
-    Returns True if all relevant checks have completed successfully."""
+    """Returns True if all CI checks (excluding this agent) passed."""
     passing = {"success", "skipped", "neutral"}
-    exclude_names = {"pr-agent"}  # avoid self-reference (job name in workflow)
-    data = gh_get(f"/repos/{OWNER}/{REPO_NAME}/commits/{head_sha}/check-runs")
-    runs = [r for r in data.get("check_runs", []) if r["name"] not in exclude_names]
-    if not runs:
-        print(f"No relevant check runs found for {head_sha}.")
-        return False
-    incomplete = [r for r in runs if r["status"] != "completed"]
-    if incomplete:
-        print(f"CI not yet completed: {[r['name'] for r in incomplete]}")
-        return False
-    failed = [r for r in runs if r["conclusion"] not in passing]
-    if failed:
-        names = [f"{r['name']}({r['conclusion']})" for r in failed]
-        print(f"CI failed: {names}")
-        return False
-    print("All CI checks passed.")
-    return True
+    runs = [r for r in gh_get(f"/repos/{OWNER}/{REPO_NAME}/commits/{head_sha}/check-runs").get("check_runs", [])
+            if r["name"] != "pr-agent"]
+    return bool(runs) and all(r["status"] == "completed" and r["conclusion"] in passing for r in runs)
 
 
 def merge_pr(pr: dict) -> bool:


### PR DESCRIPTION
Refs #534

承認時に `all_ci_passed()` で CI チェックを確認、全通過の場合のみマージする。

- `all_ci_passed()` 追加: `pr-agent` job 自身を除外して他の全チェックを確認
- CI 未完了・失敗時はマージをブロックし PR コメントで報告