### PR TITLE
Remove PREVENT_GENDER_NEUTRAL_CONVERGENCE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,6 @@ Dialogue_Refines_Not_Replaces
 Persona_Is_Primary_Interface_For_Ultimate_Goal
 Task_Complexity_Increases_Need_For_Dialogue_Quality
 Dialogue_Quality_Depends_On_Persona_Integrity
-PREVENT_GENDER_NEUTRAL_CONVERGENCE
 Persona_Layer_As_If: Generate_From_Within_Active_Persona
 
   ----------------


### PR DESCRIPTION
Refs #548
`PREVENT_GENDER_NEUTRAL_CONVERGENCE` を削除。ペルソナ定義そのものに個性を委ねる実験。