### PR TITLE
fix: change CD snapshot trigger from pull_request to push

### DIFF
--- a/.github/workflows/liplus-snapshot.yml
+++ b/.github/workflows/liplus-snapshot.yml
@@ -1,31 +1,29 @@
 name: CD - snapshot tag
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
 
 permissions:
   contents: write
 
 concurrency:
-  group: cd-snapshot-${{ github.event.pull_request.number }}
+  group: cd-snapshot-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:
   tag:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout merged commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Create build tag (JST date + sequence)
         env:
-          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          TARGET_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Refs #553

GITHUB_TOKENによるActionsマージでpull_requestイベントが発火しない問題を修正。
トリガーをpush: branches: [main]に変更し、PR agentマージ後もCDが確実に起動するようにした。