### PR TITLE
fix: dispatch CD snapshot via workflow_dispatch after PR agent merge

### DIFF
--- a/.github/scripts/liplus_pr_agent.py
+++ b/.github/scripts/liplus_pr_agent.py
@@ -277,9 +277,20 @@ def all_ci_passed(head_sha: str) -> bool:
     return bool(runs) and all(r["status"] == "completed" and r["conclusion"] in passing for r in runs)
 
 
+def dispatch_cd_snapshot(sha: str) -> None:
+    try:
+        gh_post(
+            f"/repos/{OWNER}/{REPO_NAME}/actions/workflows/liplus-snapshot.yml/dispatches",
+            {"ref": "main", "inputs": {"sha": sha}},
+        )
+        print(f"Dispatched CD snapshot for SHA {sha}")
+    except Exception as e:
+        print(f"Failed to dispatch CD snapshot: {e}")
+
+
 def merge_pr(pr: dict) -> bool:
     try:
-        gh_put(
+        result = gh_put(
             f"/repos/{OWNER}/{REPO_NAME}/pulls/{PR_NUMBER}/merge",
             {
                 "merge_method": "squash",
@@ -287,6 +298,9 @@ def merge_pr(pr: dict) -> bool:
             },
         )
         print(f"PR #{PR_NUMBER} merged.")
+        merge_sha = result.get("sha", "")
+        if merge_sha:
+            dispatch_cd_snapshot(merge_sha)
         branch = pr["head"]["ref"]
         gh_delete(f"/repos/{OWNER}/{REPO_NAME}/git/refs/heads/{branch}")
         print(f"Branch {branch} deleted.")

--- a/.github/workflows/liplus-snapshot.yml
+++ b/.github/workflows/liplus-snapshot.yml
@@ -1,29 +1,45 @@
 name: CD - snapshot tag
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit SHA to tag'
+        required: true
 
 permissions:
   contents: write
 
 concurrency:
-  group: cd-snapshot-${{ github.sha }}
+  group: cd-snapshot-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
   tag:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve target SHA
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "sha=${{ inputs.sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "sha=${{ github.event.pull_request.merge_commit_sha }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout merged commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ steps.resolve.outputs.sha }}
           fetch-depth: 0
 
       - name: Create build tag (JST date + sequence)
         env:
-          TARGET_SHA: ${{ github.sha }}
+          TARGET_SHA: ${{ steps.resolve.outputs.sha }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Refs #553

GITHUB_TOKENによるActionsマージではpull_request/pushイベントが発火しない問題を修正。
PR agentがマージ後にworkflow_dispatchでCDを明示的に起動するよう変更。
liplus-snapshot.ymlにworkflow_dispatchトリガー（sha入力付き）を追加し、
pull_requestトリガーは手動マージ時の互換性のために残した。