### PR TITLE
fix: add actions: write permission to PR agent workflow

### DIFF
--- a/.github/workflows/liplus-pr-agent.yml
+++ b/.github/workflows/liplus-pr-agent.yml
@@ -20,6 +20,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Refs #556

workflow_dispatch APIの呼び出しにactions: write権限が必要だが
liplus-pr-agent.ymlに含まれておらず403エラーが発生していた。