### PR TITLE
revert: remove commit_message from squash merge

### DIFF
--- a/.github/scripts/liplus_pr_agent.py
+++ b/.github/scripts/liplus_pr_agent.py
@@ -295,7 +295,6 @@ def merge_pr(pr: dict) -> bool:
             {
                 "merge_method": "squash",
                 "commit_title": pr["title"],
-                "commit_message": pr.get("body") or "",
             },
         )
         print(f"PR #{PR_NUMBER} merged.")


### PR DESCRIPTION
Refs #562

commit_messageの追加はissue自動クローズに効果がなかったため戻す。
GITHUB_TOKENマージ時はPRリンクでもissue自動クローズが動かない模様。