### PR TITLE
fix: add auto-merge enable step to PR creation flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,9 +358,10 @@ Operation_Rules
 
   Recommended_Flow:
   1 = create_PR (body includes "Refs #{parent_issue_number}")
-  2 = CI_pass -> review_request_auto_sent_via_codeowners
-  3 = GitHub_auto_merge_on_approval (squash + branch_delete handled by GitHub)
-  4 = parent_issue_auto_closed_by_github_on_merge
+  2 = enable_auto_merge: gh pr merge {pr} -R {owner}/{repo} --auto --squash
+  3 = CI_pass -> review_request_auto_sent_via_codeowners
+  4 = GitHub_auto_merge_on_approval (squash + branch_delete handled by GitHub)
+  5 = parent_issue_auto_closed_by_github_on_merge
 
   Real_Device_Test:
   Merge_First Then_Test_On_Main Not_A_Merge_Gate

--- a/docs/3.-Operational_GitHub.md
+++ b/docs/3.-Operational_GitHub.md
@@ -187,12 +187,17 @@ gh api repos/{owner}/{repo}/issues/{issue_number}/assignees \
 
 **CI PASS かつ構造レビューで問題がなければ、実機テストより前にマージしてよい。**
 
-マージは **GitHub の auto-merge 機能** が処理する。AI がマージコマンドを実行する必要はない。
+マージは **GitHub の auto-merge 機能** が処理する。
+
+**PR 作成直後に auto-merge を有効化すること**（これをしないと自動マージが発火しない）：
+
+```
+gh pr merge {pr_number} -R {owner}/{repo} --auto --squash
+```
 
 - squash merge を使用（リポジトリ設定で構成済み）
 - ブランチ削除は "Automatically delete head branches" 設定により自動処理される
-
-PR 本文に `Refs #xxx` が含まれていると、マージ時に GitHub が Issue を自動クローズする。
+- PR 本文に `Refs #xxx` が含まれていると、マージ時に GitHub が Issue を自動クローズする
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
Refs #570

PR作成後に `gh pr merge --auto --squash` を実行しないとauto-mergeが発火しないことが判明。
CLAUDE.md と docs/3.-Operational_GitHub.md に有効化ステップを追記。