### PR TITLE
fix: prevent PR agent from running on merged PRs

### DIFF
--- a/.github/workflows/liplus-pr-agent.yml
+++ b/.github/workflows/liplus-pr-agent.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   pr-agent:
     if: |
-      github.event_name == 'pull_request_review' ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
+      (github.event_name == 'pull_request_review' && !github.event.pull_request.merged) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Refs #572

auto-merge後にPRエージェントのコメントがissue_commentを発火させ再起動する問題を修正。
ワークフローのif条件にPRのopen状態チェックを追加。