### PR TITLE
fix: check linkedBranches when gh issue develop fails locally

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,13 @@ Operation_Rules
   ISSUE_LINK_VIA_GH_ISSUE_DEVELOP_IS_ALWAYS_REQUIRED
   GH_ISSUE_DEVELOP_MUST_PRECEDE_FIRST_PUSH_TO_GITHUB
 
+  On_Local_Error:
+  gh_issue_develop_may_fail_locally_but_succeed_on_github_side
+  check_linked_branches_before_retrying:
+    gh api graphql -f query='{ repository(owner:"{owner}",name:"{repo}") { issue(number:{number}) { linkedBranches { nodes { ref { name } } } } } }'
+  IF_LINKED = use_existing_linked_branch DO_NOT_CREATE_NEW_BRANCH
+  IF_NOT_LINKED = retry_or_escalate
+
   [Commit_Rules]
 
   Language:

--- a/docs/3.-Operational_GitHub.md
+++ b/docs/3.-Operational_GitHub.md
@@ -144,6 +144,18 @@ gh issue develop {issue_number} -R {owner}/{repo} --name {session-branch} --base
 > **順序制約**: `gh issue develop` は **GitHub への初回 push より前に実行する**。
 > すでに **GitHub 上にブランチが存在する場合**、後から実行してもリンクは張れない。
 
+### `gh issue develop` がローカルエラーで失敗した場合
+
+`gh issue develop` はローカルの git 操作に失敗しても、GitHub API 側ではブランチリンクが成功している場合がある。
+**リトライ前に必ずリンク状態を確認すること。**
+
+```
+gh api graphql -f query='{ repository(owner:"{owner}",name:"{repo}") { issue(number:{number}) { linkedBranches { nodes { ref { name } } } } } }'
+```
+
+- `linkedBranches` にブランチ名が返ってきた場合 → **そのブランチを使用する**（新規作成禁止）
+- 返ってこなかった場合 → 再試行または人間に委ねる
+
 ### 作業開始時の Assignee ルール
 
 ```


### PR DESCRIPTION
Refs #551

gh issue developがローカルエラーで失敗した場合、GitHub API側のリンク状態をGraphQLで確認するルールを追加。
リンク済みなら既存ブランチを使用し、不要な別名ブランチを作らないようにする。