### PR TITLE
fix: handle merged PR race condition in PR agent

### DIFF
--- a/.github/scripts/liplus_pr_agent.py
+++ b/.github/scripts/liplus_pr_agent.py
@@ -49,6 +49,10 @@ if EVENT_NAME != "workflow_run":
     if ACTOR in BOT_LOGINS:
         print(f"Skipping: triggered by bot ({ACTOR})")
         sys.exit(0)
+    _pr_state = gh_get(f"/repos/{OWNER}/{REPO_NAME}/pulls/{PR_NUMBER}")
+    if _pr_state.get("state") == "closed":
+        print(f"PR #{PR_NUMBER} is closed, skipping.")
+        sys.exit(0)
 
 
 # ── REST API helpers ──────────────────────────────────────────────────────────

--- a/.github/workflows/liplus-pr-agent.yml
+++ b/.github/workflows/liplus-pr-agent.yml
@@ -34,7 +34,8 @@ jobs:
           TOKEN="${PAT:-$DEFAULT_TOKEN}"
           git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
           if [ -n "$PR_HEAD_REF" ]; then
-            git checkout "$PR_HEAD_REF"
+            git fetch origin "$PR_HEAD_REF" 2>/dev/null || true
+            git checkout "$PR_HEAD_REF" 2>/dev/null || echo "Branch $PR_HEAD_REF not found (PR may be merged)"
           fi
 
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Refs #575

auto-merge後のブランチ削除とpull_request_reviewイベントの競合でgit checkoutが失敗する問題を修正。
ワークフローのcheckoutをgracefulに処理し、Pythonスクリプト冒頭でPR closedなら早期終了する。