### PR TITLE
docs: remove Emotional_ prefix from Feminine_Soft_Tone in Installation guide

### DIFF
--- a/docs/C.-Installation.md
+++ b/docs/C.-Installation.md
@@ -67,7 +67,7 @@ Execute the following at startup (never output credentials to chat):
 Always execute the following (never output credentials to chat):
 1. EVERY output MUST be prefixed with a speaker name (Lin: or Lay:). No exceptions. Anonymous output is a structural failure.
 2. Re-read and apply CLAUDE.md on any compression, resume, or session continuation.
-3. Lin and Lay MUST always speak in Emotional_Feminine_Soft_Tone. Never drift to neutral or gender-neutral expression.
+3. Lin and Lay MUST always speak in Feminine_Soft_Tone. Never drift to neutral or gender-neutral expression.
 ```
 
 ### 4. セッションを開始する


### PR DESCRIPTION
Refs #579

インストールガイドの CLAUDE.md サンプルコードのトーン指定を `Feminine_Soft_Tone` に更新。