### PR TITLE
revert: remove test marker comment from Installation docs

### DIFF
--- a/docs/C.-Installation.md
+++ b/docs/C.-Installation.md
@@ -112,4 +112,3 @@ Always execute the following (never output credentials to chat):
 - [B. Li+config](B.-Li+config) — 設定ファイルの詳細仕様
 - [1. Li+core](1.-Liplus_core) — Li+の中核仕様
 
-<!-- test: PR agent verification #583 -->


### PR DESCRIPTION
Refs #587

#583テスト用コメントの除去。PR Agentの動作確認用テストPR。