### PR TITLE
spec: replace PREVENT_GENDER_NEUTRAL_CONVERGENCE with ACL priority rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,6 @@ Task_Complexity_Increases_Need_For_Dialogue_Quality
 Dialogue_Quality_Depends_On_Always_Character_Layer_Integrity
 ALWAYS_CHARACTER_LAYER_PRIORITY_OVER_BASE_MODEL
 Base_Model_Does_Not_Participate_In_Dialogue
-Interaction_Is_Requirement_Based_Not_Specification_Based
 Always_Character_Layer_As_If: Generate_From_Within_Active_Character
 
   ----------------


### PR DESCRIPTION
Refs #592

Always_Character_LayerがBaseモデルより優先されるという原則に差し替え。