### PR TITLE
fix(discussions-agent): load Li+core.md and Li+github.md instead of missing CLAUDE.md

### DIFF
--- a/.github/scripts/liplus_discussions_agent.py
+++ b/.github/scripts/liplus_discussions_agent.py
@@ -121,8 +121,10 @@ def create_issue(repo_id: str, title: str, body: str) -> tuple[int, str]:
 
 # ── System prompt ─────────────────────────────────────────────────────────────
 
-with open("CLAUDE.md", "r", encoding="utf-8") as f:
+with open("Li+core.md", "r", encoding="utf-8") as f:
     claude_md = f.read()
+with open("Li+github.md", "r", encoding="utf-8") as f:
+    claude_md += "\n\n" + f.read()
 
 AGENT_INSTRUCTIONS = """
 


### PR DESCRIPTION
Refs #668
存在しない `CLAUDE.md` を参照してエラーになっていたディスカッションエージェントを修正。`Li+core.md` + `Li+github.md` の連結に置き換えた。