### PR TITLE
fix(discussions-agent): switch model ID to alias format to fix model identity issue

### DIFF
--- a/.github/workflows/liplus-discussions-agent.yml
+++ b/.github/workflows/liplus-discussions-agent.yml
@@ -38,5 +38,5 @@ jobs:
           COMMENT_NODE_ID: ${{ github.event.comment.node_id }}
           EVENT_NAME: ${{ github.event_name }}
           ACTOR: ${{ github.actor }}
-          CLAUDE_MODEL: claude-haiku-4-5-20251001
+          CLAUDE_MODEL: claude-haiku-4-5
         run: python .github/scripts/liplus_discussions_agent.py


### PR DESCRIPTION
Refs #670
ディスカッションエージェントが自身をSonnet 3.5と名乗る問題の対処。日付サフィックス付きID `claude-haiku-4-5-20251001` → エイリアス形式 `claude-haiku-4-5` に変更し、モデル解決の問題を切り分ける。