### PR TITLE
fix(discussions-agent): revert to claude-haiku-4-5 and inject model name into system prompt

### DIFF
--- a/.github/scripts/liplus_discussions_agent.py
+++ b/.github/scripts/liplus_discussions_agent.py
@@ -133,6 +133,7 @@ AGENT_INSTRUCTIONS = """
 # Agent_Mode
 
 ENVIRONMENT = GitHub_Discussions_Agent
+MODEL = {model}
 MODEL_ROLE = External_Intake_Chat
 RESPONSE_LANGUAGE = match_user_language (detect and respond in the same language the user is writing in)
 
@@ -164,7 +165,7 @@ EXISTING_ISSUES:
 """
 
 issue_list = get_issues()
-system_prompt = claude_md + AGENT_INSTRUCTIONS.format(issue_list=issue_list)
+system_prompt = claude_md + AGENT_INSTRUCTIONS.format(issue_list=issue_list, model=CLAUDE_MODEL)
 
 
 # ── Build conversation history ────────────────────────────────────────────────

--- a/.github/workflows/liplus-discussions-agent.yml
+++ b/.github/workflows/liplus-discussions-agent.yml
@@ -38,5 +38,5 @@ jobs:
           COMMENT_NODE_ID: ${{ github.event.comment.node_id }}
           EVENT_NAME: ${{ github.event_name }}
           ACTOR: ${{ github.actor }}
-          CLAUDE_MODEL: claude-sonnet-4-6
+          CLAUDE_MODEL: claude-haiku-4-5
         run: python .github/scripts/liplus_discussions_agent.py


### PR DESCRIPTION
Refs #674
モデルを `claude-haiku-4-5` に戻し、`AGENT_INSTRUCTIONS` に `MODEL = {model}` を追加。システムプロンプト経由でモデル名を渡すことでエージェントが自分のモデル名を正確に答えられるようにする。