### PR TITLE
spec(release): switch release notes generation to GitHub generated notes

### DIFF
--- a/Li+github.md
+++ b/Li+github.md
@@ -288,15 +288,16 @@ Operation Rules
   Use: gh release list --limit 1 (includes prereleases)
 
   Release tag rule:
-  Use existing CD-created tag = gh release create {cd_tag} --title "Li+ {version}" --prerelease
+  Use existing CD-created tag = gh release create {cd_tag} --title "Li+ {version}" --prerelease --generate-notes
   Do not create new tag = new tag creation is prohibited.
   cd_tag_format = build-YYYY-MM-DD.N (latest after target commit)
   AI-created release is always prerelease.
   Latest promotion requires human judgment.
 
   Release body rule:
-  body = empty string
-  Intent = GitHub auto-generates commit list when empty (this is desired behavior).
+  body = GitHub generated release notes
+  Command requirement = pass --generate-notes
+  Do not pass empty body via --notes "".
 
   [Notifications API]
 

--- a/docs/3.-Operational_GitHub.md
+++ b/docs/3.-Operational_GitHub.md
@@ -255,7 +255,7 @@ gh pr merge {pr_number} -R {owner}/{repo} --auto --squash
 
 -   **CD が作成したスナップショットタグ（`build-YYYY-MM-DD.N`）を使う**
 -   新規タグを作成してリリースを作ってはならない
--   コマンド例：`gh release create build-2026-02-25.14 --title "Li+ v0.13.1" --prerelease`
+-   コマンド例：`gh release create build-2026-02-25.14 --title "Li+ v0.13.1" --prerelease --generate-notes`
 
 ### AIが作成するリリースは必ずプレリリース
 
@@ -265,8 +265,9 @@ gh pr merge {pr_number} -R {owner}/{repo} --auto --squash
 
 ### リリース body ルール
 
--   **body は空にする**（内容を書かない）
--   body を空にすることで GitHub がコミット一覧を自動表示する——これは意図した動作
+-   **GitHub generated release notes を使う**
+-   `gh release create` では **`--generate-notes` を付ける**
+-   `--notes ""` のような空 body 指定は使わない
 
 ### 停止ルール
 


### PR DESCRIPTION
Refs #687
リリース手順を空 body 前提から GitHub generated release notes 前提へ変更します。
`--generate-notes` を正規手順にし、`--notes ""` を使わないルールへ更新します。