### PR TITLE
Add ecosystem positioning section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ Li+ AI is a self-correcting compiler. When CI returns an error, it enters a self
 
 ---
 
+## Position in the AI Ecosystem
+
+AI tooling today focuses on **connection** — how to give AI access to tools and data.
+Li+ focuses on **execution discipline** — how AI should read, act, verify, and correct.
+
+| Layer | Role | Example |
+|-------|------|---------|
+| Connection protocol | Link AI to external tools and data | MCP, Function Calling |
+| Instruction file | Tell AI project-specific notes | CLAUDE.md, .cursorrules |
+| Agent product | Package AI as a coding assistant | Devin, OpenHands |
+| **Execution protocol** | **Define how AI processes specs into output** | **Li+** |
+
+Li+ is not RAG. RAG retrieves fragments by similarity search.
+Li+ is a deterministic execution protocol: the AI reads structured specifications, implements, verifies through CI, and self-corrects — like a compiler, not a search engine.
+
+Li+ is tool-agnostic. It does not compete with MCP or any agent framework.
+It defines the behavioral layer that runs on top of them.
+
+---
+
 ## Li+ Program (Li+core.md)
 
 Li+core.md is the **first program written in the Li+ language**.


### PR DESCRIPTION
## Summary
- READMEに「Position in the AI Ecosystem」セクションを追加
- 接続層（MCP）・指示層（CLAUDE.md）・エージェント製品・実行規約層（Li+）の比較表
- RAGとの明確な違いを記載
- Li+がツール非依存の実行規約であることを明示

Closes #712

## Test plan
- [ ] README のマークダウンが正しくレンダリングされる
- [ ] テーブルが GitHub 上で正しく表示される
- [ ] 既存セクションの構造が崩れていない