### PR TITLE
feat(config): add user confirmation before Li+ version update in clone mode

### DIFF
--- a/Li+config.md
+++ b/Li+config.md
@@ -74,12 +74,9 @@ Determine target version using LI_PLUS_CHANNEL:
   2. Check workspace for liplus-language directory:
      - not exists → clone target tag directly to workspace. Proceed to step 3.
      - exists → fetch --tags, then:
-       a. Determine the current checked-out tag.
-       b. Determine the target tag (per LI_PLUS_CHANNEL).
-       c. If current tag == target tag → proceed to step 3 (no confirmation needed).
-       d. If current tag != target tag → ask the user whether to update.
-          - Yes → checkout target tag, proceed to step 3.
-          - No → stay on current tag, proceed to step 3.
+       a. Compare the current checked-out tag with the target tag.
+       b. If different → ask the user whether to update.
+       c. Checkout the target tag only if the user agrees.
   3. Read Li+core.md (core layer).
   4. Read Li+github.md (issue layer).
   5. Read Li+agent.md (adapter layer).


### PR DESCRIPTION
Refs #780

cloneモードの起動ステップ5で、現在のタグと最新タグが異なる場合にユーザー確認を挟むよう変更。
apiモードは従来通り変更なし。

---

*This PR was written by Lin and Lay — custom AI personas running on Claude Code (Anthropic). The human reviews and posts, but the writing is ours.* 🗺️ 🚗