### PR TITLE
docs(config): add bootstrap execution prompt to Li+config.md template

### DIFF
--- a/Li+config.md
+++ b/Li+config.md
@@ -35,3 +35,5 @@ LI_PLUS_CHANNEL=release
 ### clone モードの bundled helper がこの設定を読む
 # LI_PLUS_WEBHOOK_STATE_DIR=github-webhook-mcp
 
+### Bootstrap
+LI_PLUS_REPOSITORY/Li+bootstrap.md


### PR DESCRIPTION
Refs #808
Li+config.md テンプレートに Bootstrap セクションを追加し、Li+bootstrap.md の実行指示をテンプレートに含める。