### PR TITLE
ci(discussions): restrict agent responses to AI Request and Q&A categories only

### DIFF
--- a/.github/workflows/liplus-discussions-agent.yml
+++ b/.github/workflows/liplus-discussions-agent.yml
@@ -10,7 +10,11 @@ jobs:
   agent:
     if: |
       github.actor != 'github-actions[bot]' &&
-      github.actor != 'liplus-lin-lay'
+      github.actor != 'liplus-lin-lay' &&
+      (
+        github.event.discussion.category.slug == 'ai-request' ||
+        github.event.discussion.category.slug == 'q-a'
+      )
     runs-on: ubuntu-latest
     permissions:
       discussions: write


### PR DESCRIPTION
Refs #818
Discussions Agentのif条件にcategory slugフィルタを追加し、AI Request・Q&Aカテゴリのみに応答を限定。