### PR TITLE
Move auto-merge setup from Merge to PR Creation section

### DIFF
--- a/Li+operations.md
+++ b/Li+operations.md
@@ -139,7 +139,9 @@ Event-Driven Operations
     order = parent first, then closed children (omit deferred and open children).
   Detail belongs in issue, not in PR.
 
-  On PR created -> proceed to [CI Loop] immediately, no human instruction required.
+  On PR created:
+  1 = if repository allows auto-merge: gh pr merge {pr} -R {owner}/{repo} --auto --squash
+  2 = proceed to [CI Loop] immediately, no human instruction required.
 
   [CI Loop]
 
@@ -191,11 +193,9 @@ Event-Driven Operations
 
   [Merge]
 
-  Auto-merge flow:
-  1 = enable auto-merge: gh pr merge {pr} -R {owner}/{repo} --auto --squash
-  2 = GitHub auto-merge on approval (squash + branch delete handled by GitHub)
+  If auto-merge was enabled at PR creation: GitHub merges automatically on approval.
 
-  Manual merge flow:
+  Manual merge flow (auto-merge unavailable or not enabled):
   1 = confirm merge strategy with human (squash / merge / rebase)
   2 = gh pr merge {pr} -R {owner}/{repo} --{strategy}
 

--- a/docs/3.-Operations.md
+++ b/docs/3.-Operations.md
@@ -140,7 +140,9 @@ gh api repos/{owner}/{repo}/contents/{path}  # PUT base64 sha
 
 issue ごとのブロック形式で記述する。親 issue → `Refs #xxx`、クローズ済み子 issue → `Refs sub #xxx`。各ブロックに2〜3行の要約を書く。詳細は issue を参照。deferred・open のまま残す子 issue は含めない。
 
-PR 作成後、CI ループへ即座に移行する。人間の指示は不要。
+PR 作成後：
+1. リポジトリが auto-merge を許可している場合、auto-merge を有効化する：`gh pr merge {pr} -R {owner}/{repo} --auto --squash`
+2. CI ループへ即座に移行する。人間の指示は不要。
 
 ---
 
@@ -211,17 +213,9 @@ gh pr view {pr} -R {owner}/{repo} --json reviewDecision --jq '.reviewDecision'
 
 ## マージ
 
-### Auto-merge フロー
+PR 作成時に auto-merge が有効化されている場合、レビュー承認後に GitHub が自動的にスカッシュマージとブランチ削除を処理する。
 
-PR 作成直後に auto-merge を有効化する。
-
-```
-gh pr merge {pr} -R {owner}/{repo} --auto --squash
-```
-
-レビュー承認後、GitHub auto-merge がスカッシュマージとブランチ削除を自動処理する。
-
-### 手動マージフロー
+### 手動マージフロー（auto-merge が利用不可または未設定の場合）
 
 マージ戦略（squash / merge / rebase）を人間に確認してから実行する。
 


### PR DESCRIPTION
Refs #833
auto-merge設定のステップをPR Creationセクションに移動し、Mergeセクションから削除。
実行タイミングとドキュメント配置のずれによる設定忘れを防止する。