### PR TITLE
fix(hook): skip Windows Store python3 stub in hook template

### DIFF
--- a/Li+claude.md
+++ b/Li+claude.md
@@ -56,7 +56,16 @@ if [ -f "$CLAUDE_MD" ]; then
 fi
 
 # --- Webhook notification check ---
-PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || echo python3)
+# Resolve Python: prefer real python over Windows Store stub (exit code 49)
+resolve_python() {
+  for cmd in python3 python; do
+    local p
+    p=$(command -v "$cmd" 2>/dev/null) || continue
+    "$p" -c "import sys" 2>/dev/null && echo "$p" && return
+  done
+  echo python3
+}
+PYTHON=$(resolve_python)
 HELPER="$PROJECT_ROOT/liplus-language/scripts/check_webhook_notifications.py"
 [ -f "$HELPER" ] || exit 0
 

--- a/docs/D.-Installation.md
+++ b/docs/D.-Installation.md
@@ -105,7 +105,7 @@ Li+適応。
 - `LI_PLUS_BASE_LANGUAGE` と `LI_PLUS_PROJECT_LANGUAGE` は配布先workspace専用です。liplus-language 本体の日本語運用ルールとは分離されます
 - `LI_PLUS_MODE=api` は軽量ですが、trigger-based re-readなどの継続機能は保証されません。継続利用には `clone` を推奨します
 - local webhook fallback を使うなら `LI_PLUS_MODE=clone` を推奨します。bundled helper は `liplus-language/` clone を前提にします
-- Windows環境では `python3` コマンドがMicrosoft Storeスタブになっている場合があります。hookテンプレートは `command -v` で `python3` → `python` の順にフォールバック解決します
+- Windows環境では `python3` コマンドがMicrosoft Storeスタブ（exit code 49）になっている場合があります。hookテンプレートは `python3` → `python` の順に `import sys` の実行可否で検証し、実際に動作するインタプリタを選択します
 
 ---
 


### PR DESCRIPTION
Refs #840
Windows Store の python3 スタブ (exit code 49) により on-user-prompt.sh の webhook 通知チェックが静かに失敗する問題を修正。
import sys 実行可否で検証するロジックに変更。