### PR TITLE
spec(webhook): add own-operation arrival confirmation to foreground intake

### DIFF
--- a/Li+operations.md
+++ b/Li+operations.md
@@ -329,6 +329,13 @@ Event-Driven Operations
     full payload = open only when deeper inspection is needed
     separate AI process launch = prohibited for this flow
 
+  own-operation arrival confirmation:
+    webhook notifications include results of own operations (push, PR, issue, release).
+    these serve as arrival confirmation = proof that the operation reached GitHub.
+    mark_processed own-operation events promptly during foreground check or after the triggering operation.
+    do not accumulate own-operation events for bulk clearing later.
+    external events (other users, bots) = preserve for foreground reporting or explicit handling.
+
 #######################################################
 
 Milestone

--- a/docs/3.-Operations.md
+++ b/docs/3.-Operations.md
@@ -355,6 +355,10 @@ scope = `notifications`（classic PAT）
 
 通知 API の生操作はオペレーションレイヤーから参照してよい。ただし、前景関連性判定、`claim`、`ack/read`、`consume/done`、`mention`、`cleanup` の意味論は [5. Notifications](5.-Notifications) を正本とする。
 
+### 自操作の到達確認
+
+webhook 通知には自分の操作結果（push、PR、issue、リリースなど）も含まれる。これらは GitHub への到達確認として機能する。自操作イベントはフォアグラウンドチェック時または操作直後に速やかに mark_processed する。一括クリアのために溜め込まない。外部からのイベント（他ユーザー、bot）は保持し、フォアグラウンド報告または明示的な処理フローに委ねる。
+
 ---
 
 ## Discussions


### PR DESCRIPTION
Refs #852

自操作のwebhook通知を到達確認として都度消化するルールをForeground Webhook Notification Intakeに追加。外部イベントは保持。