### PR TITLE
chore(operations): change release title format from 'Li+ {version}' to '{version}'

### DIFF
--- a/Li+operations.md
+++ b/Li+operations.md
@@ -280,7 +280,7 @@ Event-Driven Operations
 
   Release tag and title rule:
   Tag format and release title follow project convention.
-  Default (Li+ language): cd_tag = build-YYYY-MM-DD.N, title = "Li+ {version}"
+  Default (Li+ language): cd_tag = build-YYYY-MM-DD.N, title = "{version}" (e.g. "v1.9.0")
   npm package projects: tag = v{semver}, title = "v{semver}"
   If project has CD workflow that creates tags: use existing CD-created tag, do not create new tag.
   If project uses npm version: tag is created by npm version command.

--- a/docs/3.-Operations.md
+++ b/docs/3.-Operations.md
@@ -308,7 +308,7 @@ gh release list --limit 1  # プレリリースを含む
 
 | プロジェクト種別 | タグ形式 | タイトル形式 |
 |---|---|---|
-| Li+ language（デフォルト） | `build-YYYY-MM-DD.N` | `Li+ {version}` |
+| Li+ language（デフォルト） | `build-YYYY-MM-DD.N` | `{version}`（例: `v1.9.0`） |
 | npm パッケージ | `v{semver}` | `v{semver}` |
 
 CD workflow がタグを作成するプロジェクトでは、既存の CD 作成タグを使い、新規タグを作らない。npm version を使うプロジェクトでは、npm version コマンドがタグを作成する。


### PR DESCRIPTION
Refs #858

リリースタイトルから「Li+」プレフィックスを削除する規約変更。全137件の既存リリースタイトルも一括リネーム済み。