### PR TITLE
fix(pr-body): use 'Part of' for parent issue reference to prevent auto-close

### DIFF
--- a/Li+operations.md
+++ b/Li+operations.md
@@ -141,6 +141,8 @@ Event-Driven Operations
       line1 = "Refs #{issue_number}" or "Refs sub #{child_issue_number}"
       line2_to_3 = two to three line summary of that issue
     order = parent first, then closed children (omit deferred and open children).
+    parent issue reference: use "Part of #{parent_number}" instead of "Refs".
+    "Refs" triggers GitHub auto-close on merge. Parent issues must not be auto-closed by sub-issue PRs.
   Detail belongs in issue, not in PR.
 
   On PR created:

--- a/docs/3.-Operations.md
+++ b/docs/3.-Operations.md
@@ -142,7 +142,9 @@ gh api repos/{owner}/{repo}/contents/{path}  # PUT base64 sha
 
 ### PR 本文形式
 
-issue ごとのブロック形式で記述する。親 issue → `Refs #xxx`、クローズ済み子 issue → `Refs sub #xxx`。各ブロックに2〜3行の要約を書く。詳細は issue を参照。deferred・open のまま残す子 issue は含めない。
+issue ごとのブロック形式で記述する。対象 issue → `Refs #xxx`、クローズ済み子 issue → `Refs sub #xxx`。各ブロックに2〜3行の要約を書く。詳細は issue を参照。deferred・open のまま残す子 issue は含めない。
+
+親 issue への参照は `Part of #xxx` を使う。`Refs` はマージ時に GitHub が自動クローズするため、sub-issue の PR で親が意図せずクローズされるのを防ぐ。
 
 PR 作成後：
 1. リポジトリが auto-merge を許可している場合、auto-merge を有効化する：`gh pr merge {pr} -R {owner}/{repo} --auto --squash`


### PR DESCRIPTION
Refs #861

親issueへのPR body参照を「Refs」から「Part of」に変更。sub-issueのPRマージで親issueが自動クローズされる問題を防ぐ。