### PR TITLE
fix(hook): increase webhook foreground check limit from 5 to 50

### DIFF
--- a/Li+agent.md
+++ b/Li+agent.md
@@ -84,7 +84,7 @@ Use only in hosts that can run local commands from the workspace before replying
        1. `LI_PLUS_WEBHOOK_STATE_DIR` from `Li+config.md` (absolute path or `workspace_root`-relative path)
        2. `workspace_root/github-webhook-mcp`
        3. `workspace_root/../github-webhook-mcp`
-     - if the bundled helper exists at `workspace_root/liplus-language/scripts/check_webhook_notifications.py` and the state dir resolves, run it in inspect mode (`--limit 5`) and pass cheap foreground hints such as repo / branch when available
+     - if the bundled helper exists at `workspace_root/liplus-language/scripts/check_webhook_notifications.py` and the state dir resolves, run it in inspect mode (`--limit 50`) and pass cheap foreground hints such as repo / branch when available
    - else: skip silently.
 3. Mention notifications only when foreground-matched items or exceptional notable items exist.
 4. Do not auto-consume the local backlog from this foreground inspect path. `claim` / `read` / `done` / `cleanup` require explicit helper commands or a deeper workflow that owns the notification.

--- a/Li+claude.md
+++ b/Li+claude.md
@@ -83,7 +83,7 @@ CURRENT_BRANCH=$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || ech
 HELPER_ARGS=(
   --workspace-root "$PROJECT_ROOT"
   "${STATE_DIR_ARGS[@]}"
-  --limit 5
+  --limit 50
 )
 [ -n "$CURRENT_REPO" ] && HELPER_ARGS+=(--repo "$CURRENT_REPO")
 if [ -n "$CURRENT_BRANCH" ]; then


### PR DESCRIPTION
Refs #863

フォアグラウンドwebhookチェックの取得件数を5→50に増加。1回のPRサイクルで10件以上発生するため、5件では重要な通知（レビュー等）を見落とす。