### PR TITLE
fix(config): clarify bootstrap execution instruction as imperative sentence

### DIFF
--- a/Li+config.md
+++ b/Li+config.md
@@ -31,5 +31,5 @@ LI_PLUS_CHANNEL=release
 ### clone モードの bundled helper がこの設定を読む
 # LI_PLUS_WEBHOOK_STATE_DIR=github-webhook-mcp
 
-## Bootstrapを実行
-LI_PLUS_REPOSITORY/Li+bootstrap.md
+## Bootstrap
+Read and execute LI_PLUS_REPOSITORY/Li+bootstrap.md


### PR DESCRIPTION
Refs #867

Li+config.md テンプレート末尾の bootstrap 指示を、パス参照から明示的な命令文に変更。
AI が「ただのパス表記」と解釈して bootstrap をスキップする事象を防止する。