### PR TITLE
spec(operations): add language rules for PR title and body

### DIFF
--- a/Li+operations.md
+++ b/Li+operations.md
@@ -136,6 +136,11 @@ Event-Driven Operations
 
   [PR Creation]
 
+  Language:
+  Title = ASCII English only, single line.
+  Body  = Japanese.
+  Consistent with Commit Rules.
+
   PR body format:
     per issue block:
       line1 = "Refs #{issue_number}" or "Refs sub #{child_issue_number}"

--- a/docs/3.-Operations.md
+++ b/docs/3.-Operations.md
@@ -148,6 +148,13 @@ gh api repos/{owner}/{repo}/contents/{path}  # PUT base64 sha
 
 ## PR 作成
 
+### 言語
+
+- タイトル：ASCII 英語のみ、1行
+- ボディ：日本語
+
+コミットルールと同一。
+
 ### PR 本文形式
 
 issue ごとのブロック形式で記述する。対象 issue → `Refs #xxx`、クローズ済み子 issue → `Refs sub #xxx`。各ブロックに2〜3行の要約を書く。詳細は issue を参照。deferred・open のまま残す子 issue は含めない。


### PR DESCRIPTION
Refs #898

PR Creation セクションに PR タイトル・ボディの言語ルールを追加。
Commit Rules と同じ規約（Title = ASCII English, Body = Japanese）を明示化した。