### PR TITLE
spec(adapter): add worktree-based parallel subagent execution rules

### DIFF
--- a/Li+agent.md
+++ b/Li+agent.md
@@ -110,6 +110,24 @@ Main agent responsibility after subagent completion:
 - For CHANGES_REQUESTED: read review comments, judge against issue requirements, then delegate fix to subagent.
 - For release: confirm version type and tag with human.
 - Main never reads Li+operations.md directly when subagent is available.
+
+Worktree parallel execution:
+Optional optimization for parallel delegation (2+ subagents).
+Serial delegation does not require worktrees.
+
+Lifecycle — main agent owns all worktree operations:
+  1. Create branch: `gh issue develop` (establishes issue link). One branch per issue.
+  2. Create worktree: `git worktree add workspace/.worktrees/{repo}-{issue_number}/ {branch_name}`
+  3. Delegate: convey worktree absolute path in addition to standard delegation info.
+  4. Subagent works entirely within the given worktree path. Subagent does not create, move, or remove worktrees.
+  5. Cleanup: after PR merge, `git worktree remove`. Across sessions, existing worktrees may be reused.
+
+Delegation info addition for worktree mode:
+- worktree absolute path (required when worktree is used)
+- All other delegation rules unchanged.
+
+Constraint:
+- `EnterWorktree` (host feature) switches session-wide CWD. Not suitable for parallel subagents. Use raw `git worktree add` + absolute paths.
 #######################################################
 
 # --- Li+ END ---

--- a/docs/4.-Adapter.md
+++ b/docs/4.-Adapter.md
@@ -168,6 +168,19 @@ bootstrap は次回セッションから有効。現セッションは Li+config
 
 サブエージェント完了後、メインエージェントは報告を受けて次のアクションを判断する。CHANGES_REQUESTED の場合はレビューコメントを読み、issue 要求と照合したうえで修正をサブエージェントに委任する。リリースの場合はバージョン種別とタグを人間に確認する。サブエージェントが利用可能な場合、メインエージェントは Li+operations.md を直接読まない。
 
+### worktree 並列実行
+
+2つ以上のサブエージェントを並列委任する場合のオプショナル最適化。直列委任では不要。
+
+ライフサイクルはメインエージェントが管理する：
+1. `gh issue develop` でブランチを作成（issue リンク確立）
+2. `git worktree add workspace/.worktrees/{repo}-{issue_number}/ {branch_name}` で作業ディレクトリを分離
+3. サブエージェントへの委任時に worktree 絶対パスを追加で伝達
+4. サブエージェントは渡された worktree パス内でのみ作業する。worktree の作成・移動・削除は行わない
+5. PR マージ後に `git worktree remove` で片付け。セッション跨ぎでは既存 worktree を再利用できる
+
+`EnterWorktree`（ホスト機能）はセッション全体の CWD を切り替えるため、並列サブエージェントには不適。素の `git worktree add` と絶対パス指定を使用する。
+
 ---
 
 ## 進化


### PR DESCRIPTION
Refs #910
サブエージェント並列委任時の git worktree ベース作業ディレクトリ分離ルールを Li+agent.md Subagent_Delegation セクションに追加。
docs/4.-Adapter.md にも対応する仕様記述を追加。