### PR TITLE
docs: rewrite README from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Li+ addresses **what should be satisfied** — and governs how an AI prioritizes
 ## Quick Start
 
 1. Download `Li+config.md` from the [latest release](https://github.com/Liplus-Project/liplus-language/releases/latest)
-2. Place it in your workspace root
-3. Start a session — the AI bootstraps Li+ automatically
+2. Place it in your workspace root and edit the settings
+3. Start a session and tell the AI: "Execute the workspace Li+config.md" (first time requires security approval)
 
 See the [Installation Guide](https://github.com/Liplus-Project/liplus-language/wiki/C.-Installation) for details.
 


### PR DESCRIPTION
## 概要

README を構成から全面改修。

- Quick Start を最上部に配置し、初見者の導線を改善
- 5層レイヤーテーブル（Notifications Layer 追加）
- Prompt vs Li+ 対比表を新設
- Compatibility テーブル刷新
- Wiki 全ページリンク（5.-Notifications 含む）
- 全体をコンパクト化

Refs #952

## テスト計画

- [ ] README の表示確認（GitHub上でのレンダリング）
- [ ] Wiki リンクの動作確認
- [ ] Release ページリンクの動作確認