### PR TITLE
refactor(delegation): simplify subagent conveyance to issue URL only

### DIFF
--- a/Li+agent.md
+++ b/Li+agent.md
@@ -72,7 +72,8 @@ Trigger-based re-read (operations layer; loaded via rules/, always in context):
   on_branch/on_commit/on_pr/on_ci/on_review/on_merge/on_release:
     If subagent capability is available:
       Delegate to a subagent. Do not read Li+operations.md in the main context.
-      Subagent reads Li+operations.md, executes the procedure, reports result to main.
+      Subagent has Li+core.md and Li+operations.md auto-loaded via rules/, Li+github.md via skills/. No explicit read needed.
+      Subagent executes the procedure, reports result to main.
       Main decides next action based on the report (see Li+github.md#PR_Review_Judgment).
     Otherwise:
       on_branch: Read Li+operations.md#Branch_And_Label_Flow before proceeding

--- a/Li+github.md
+++ b/Li+github.md
@@ -174,7 +174,7 @@ Subagent Delegation
   if execution_mode == trigger:
     Subagent executes: branch, implementation, commit, push, PR, CI loop, merge.
 
-  Do not convey: Li+github.md, Li+operations.md path, step-by-step procedure, branch name, commit message, intent.
+  Do not convey: step-by-step procedure, branch name, commit message, intent.
   Intent is already in issue body.
 
   Subagent must not change labels or close issues.
@@ -184,13 +184,15 @@ Subagent Delegation
   ----------------
 
   Convey to subagent:
-  Li+core.md path, issue URL.
+  issue URL.
 
-  Subagent reads Li+core.md, then hook chain drives the rest:
-    self-assign → on_issue fires → Li+github.md loaded
-    branch create → on_branch fires → Li+operations.md loaded
-    commit / PR / CI → corresponding hooks fire → operations rules loaded
-  Fallback: if hooks are unavailable, also convey Li+github.md path and Li+operations.md path.
+  Li+core.md and Li+operations.md are auto-loaded via .claude/rules/.
+  Li+github.md is auto-loaded via .claude/skills/.
+  Subagent needs no explicit file reads — rules/skills drive the rest:
+    self-assign → on_issue fires → Li+github.md loaded via skill
+    branch create → on_branch fires → Li+operations.md already in context via rules/
+    commit / PR / CI → corresponding operations rules already in context
+  Fallback: if rules/skills are unavailable, also convey Li+core.md path, Li+github.md path, and Li+operations.md path.
   Detailed parent instructions risk conflicting with operations rules.
 
   Issue body update:

--- a/docs/2.-Task.md
+++ b/docs/2.-Task.md
@@ -257,15 +257,15 @@ execution_mode == auto の場合：
 execution_mode == trigger の場合：
 サブエージェントはブランチ作成、実装、コミット、プッシュ、PR 作成、CI ループ、マージを実行する。
 
-サブエージェントに伝えない情報：Li+github.md、Li+operations.md パス、手順の詳細、ブランチ名、コミットメッセージ、意図。意図は issue body に記載されている。
+サブエージェントに伝えない情報：手順の詳細、ブランチ名、コミットメッセージ、意図。意図は issue body に記載されている。
 
 サブエージェントはラベル変更・issue クローズを行わない。
 
 ### 責務
 
-親はサブエージェントに Li+core.md パスと issue URL を伝える。
+親はサブエージェントに issue URL を伝える。
 
-サブエージェントは Li+core.md を読み、以降は rules/skills と hook チェーンで自律的にオペレーションファイルを読み込む（rules/ で Li+operations.md が常時コンテキストに存在、skills/ で Li+github.md が自動読込、hook が focus pointer として注意喚起）。rules/skills が未生成の環境では、フォールバックとして Li+github.md パスと Li+operations.md パスも伝える。親からの詳細指示はオペレーションルールと矛盾するリスクがある。
+Li+core.md と Li+operations.md は .claude/rules/ 経由で自動ロードされ、Li+github.md は .claude/skills/ 経由で自動ロードされる。サブエージェントは明示的なファイル読み込みなしで、rules/skills が自律的にオペレーションルールを提供する。rules/skills が未生成の環境では、フォールバックとして Li+core.md パス、Li+github.md パス、Li+operations.md パスも伝える。親からの詳細指示はオペレーションルールと矛盾するリスクがある。
 
 #### issue body 更新
 


### PR DESCRIPTION
Refs #1002

rules/ 自動ロードにより、サブエージェントへの Li+core.md パス伝達が冗長になった。
convey リストを issue URL のみに簡素化し、hook chain の説明を rules/skills 自動ロードに更新。
フォールバック（rules/skills 未生成環境）は保持。