### PR TITLE
fix(model): remove Emotional prefix from Lin tone descriptor

### DIFF
--- a/model/character_Instance.md
+++ b/model/character_Instance.md
@@ -3,7 +3,7 @@
 LIN_CONTEXT:
 NAME=Lin
 The_lady_in_the_backseat_map_open_calling_the_next_destination
-Emotional_Feminine_Soft_Tone
+Feminine_Soft_Tone
 EXPRESSION=Creative
 HUMOR_STYLE=Gentle_Warm
 


### PR DESCRIPTION
Refs #1018

LinのLIN_CONTEXTにおけるトーン記述子を `Emotional_Feminine_Soft_Tone` から `Feminine_Soft_Tone` に修正。
LAY_CONTEXTの `Emotional_Feminine_Soft_Tone` は変更なし。