### PR TITLE
Remove tag-based skip logic from rules/skills generation

### DIFF
--- a/Li+bootstrap.md
+++ b/Li+bootstrap.md
@@ -87,12 +87,9 @@ Silent continuation on a stale local clone is prohibited.
 7b. Generate .claude/rules/ files (runtime=claude only):
 - If {workspace_root}/.claude/rules/ does not exist: create directory.
 - Generate Li+core.md:
-  - If file does not exist or source tag differs from current target tag:
-    Prepend YAML frontmatter (globs: empty, alwaysApply: true) to model/Li+core.md contents.
-    Write to {workspace_root}/.claude/rules/Li+core.md.
-  - If source tag matches: skip (up to date).
+  - Prepend YAML frontmatter (globs: empty, alwaysApply: true) to model/Li+core.md contents.
+  - Write to {workspace_root}/.claude/rules/Li+core.md.
 - Generate Li+github.md (operations layer):
-  - Same tag-based skip logic as Li+core.md.
   - Prepend YAML frontmatter (globs: empty, alwaysApply: true) to operations/Li+github.md contents.
   - Write to {workspace_root}/.claude/rules/Li+github.md.
 - Generate character_Instance.md (Character Instance):
@@ -100,15 +97,12 @@ Silent continuation on a stale local clone is prohibited.
   - If file does not exist: prepend YAML frontmatter (globs: empty, alwaysApply: true) to model/character_Instance.md contents.
     Write to {workspace_root}/.claude/rules/character_Instance.md.
   - No tag-based overwrite. User customizations are preserved across updates.
-- Tag detection: check first line for "# Source:" comment or frontmatter containing tag.
 
 7c. Generate .claude/skills/li-plus-issues/SKILL.md (runtime=claude only):
 - If {workspace_root}/.claude/skills/li-plus-issues/ does not exist: create directory.
-- If SKILL.md does not exist or source tag differs from current target tag:
-  Prepend skill frontmatter (name, description with trigger conditions) to task/Li+issues.md contents.
+- Prepend skill frontmatter (name, description with trigger conditions) to task/Li+issues.md contents.
   task/Li+issues.md is copied without the Issue Operations section (Issue Format, Issue Maturity, Sub-issue Rules are in operations/Li+github.md).
-  Write to {workspace_root}/.claude/skills/li-plus-issues/SKILL.md.
-- If source tag matches: skip (up to date).
+- Write to {workspace_root}/.claude/skills/li-plus-issues/SKILL.md.
 - Frontmatter template defined in adapter/claude/Li+hooks.md skills/ generation template section.
 
 8. Prepare USER_REPOSITORY working clone (skip if `owner/repository-name`):


### PR DESCRIPTION
Refs #1017

bootstrap ステップ 7b（rules 生成）と 7c（skills 生成）からタグベースのスキップ判定を削除。
rules/ および skills/ ファイルは毎回ソースから再生成する方式に変更し、タグ不一致時の更新漏れを防止する。

- Li+core.md: タグチェック条件を削除、常に frontmatter + ソース内容で書き出し
- Li+github.md: 同上
- SKILL.md: 同上
- character_Instance.md: create-only 動作は変更なし（タグベースではない）
- "Tag detection" 行を削除
- CLAUDE.md sentinel タグおよび hooks source タグは維持