### PR TITLE
fix(adapter): replace grep -oP with awk for Windows PCRE compat

### DIFF
--- a/adapter/claude/Li+hooks.md
+++ b/adapter/claude/Li+hooks.md
@@ -75,7 +75,7 @@ fi
 
 # --- Webhook notification reminder ---
 # Read LI_PLUS_WEBHOOK_DELIVERY from Li+config.md (channel = skip polling reminder)
-WEBHOOK_DELIVERY=$(grep -oP '(?<=LI_PLUS_WEBHOOK_DELIVERY=)\S+' "$PROJECT_ROOT/Li+config.md" 2>/dev/null)
+WEBHOOK_DELIVERY=$(awk -F= '/^LI_PLUS_WEBHOOK_DELIVERY=/{print $2}' "$PROJECT_ROOT/Li+config.md" 2>/dev/null)
 if [ "$WEBHOOK_DELIVERY" != "channel" ]; then
   echo ""
   echo "━━━ Webhook: check pending notifications ━━━"


### PR DESCRIPTION
Refs #1030

Windows Git Bash の GNU grep 3.0 は PCRE (`-P`) をサポートしていないため、`on-user-prompt.sh` 内の `LI_PLUS_WEBHOOK_DELIVERY` 読み取りで実行時エラーが発生する。
`grep -oP` を `awk -F=` に置換し、POSIX 互換の方法で同等の値抽出を行うように修正。