### PR TITLE
Restructure bootstrap into phase-based flow

### DIFF
--- a/Li+bootstrap.md
+++ b/Li+bootstrap.md
@@ -4,17 +4,35 @@ Session startup procedure for Li+.
 Execute at session start. Never output credentials to chat.
 Read Li+config.md first to resolve all settings before executing this file.
 
-1. Detect runtime environment:
+Phases execute in order. Each phase declares its dependencies.
+
+## Phase 1: Environment Detection
+
+Dependencies: none.
+
+1.1. Detect runtime environment:
 - if environment variable CODEX_HOME or CODEX_THREAD_ID exists: runtime=codex
 - elif environment variable CLAUDECODE exists: runtime=claude
 - else: ask user once (Claude or Codex?) and proceed with answer.
 
-2. Secure Li+config.md permissions:
+1.2. Secure Li+config.md permissions:
 - Linux/Mac only: `chmod 600 Li+config.md` (owner read/write only, since the file contains tokens).
 - Skip if permissions are already 600 or stricter.
 - Windows: skip (NTFS ACL under user profile directories is already restricted by default).
 
-3. Resolve workspace language contract:
+## Phase 2: Authentication and Settings
+
+Dependencies: Phase 1 (runtime detected).
+
+2.1. Install gh CLI:
+- Install only if `~/.local/bin/gh` does not exist. No sudo. No PATH update.
+- Always use full path `~/.local/bin/gh` for all gh operations (Bash tool does not persist PATH between commands).
+- /tmp is forbidden (permission conflicts with other sessions).
+- Steps: `mkdir -p ~/.local/bin` -> curl tarball to `~/.local/bin/gh.tar.gz` -> extract in place -> place `~/.local/bin/gh` -> delete tarball.
+
+2.2. Load GH_TOKEN and authenticate.
+
+2.3. Resolve workspace language contract:
 - These values apply to the current workspace only. They do not change LI_PLUS_REPOSITORY governance.
 - LI_PLUS_BASE_LANGUAGE = dialogue language for this workspace.
 - LI_PLUS_PROJECT_LANGUAGE = artifact language for this workspace (issue/PR/commit body, requirements).
@@ -24,71 +42,66 @@ Read Li+config.md first to resolve all settings before executing this file.
   - Write resolved values to Li+config.md.
 - Runtime precedence and scope rules are defined in the adapter's Workspace_Language_Contract.
 
-3b. Resolve webhook delivery mode (optional):
+2.4. Resolve webhook delivery mode (optional):
 - LI_PLUS_WEBHOOK_DELIVERY setting (`channel` or `poll`) is read by the adapter at runtime.
 - Default if unset: poll. No bootstrap action needed.
 
-4. Install gh CLI:
-- Install only if `~/.local/bin/gh` does not exist. No sudo. No PATH update.
-- Always use full path `~/.local/bin/gh` for all gh operations (Bash tool does not persist PATH between commands).
-- /tmp is forbidden (permission conflicts with other sessions).
-- Steps: `mkdir -p ~/.local/bin` → curl tarball to `~/.local/bin/gh.tar.gz` → extract in place → place `~/.local/bin/gh` → delete tarball.
+## Phase 3: Li+ Source Resolution
 
-5. Load GH_TOKEN and authenticate.
+Dependencies: Phase 2 (gh CLI authenticated).
 
-6. Load Li+ layers from LI_PLUS_REPOSITORY:
-Determine target version using LI_PLUS_CHANNEL:
+3.1. Determine target version using LI_PLUS_CHANNEL:
 - latest: use the Latest release tag.
 - release: use the most recent tag including pre-releases.
-Version check is mandatory on every startup before reading Li+ layers.
-Silent continuation on a stale local clone is prohibited.
-- Check LI_PLUS_MODE:
-  - api: fetch model/Li+core.md for the target version via GitHub API from LI_PLUS_REPOSITORY.
-    Conditionally fetch task/Li+issues.md (skip if the adapter loads it automatically per-turn).
-  - clone: execute in order:
-  1. Target repo is the target version of LI_PLUS_REPOSITORY.
-  2. Check workspace for repository directory (derived from LI_PLUS_REPOSITORY name):
-     - not exists → clone target tag directly to workspace. Proceed to step 3.
-     - exists → fetch --tags, then:
-       a. Resolve and report both values: current checked-out tag and target tag from LI_PLUS_CHANNEL.
-       b. If same → continue.
-       c. If different → ask the user how to proceed before reading Li+ layers.
-          Do not report bootstrap completion before this choice is resolved.
-          Minimum choices:
-          - update now to the target tag
-          - stay on the current tag for this session
-       d. Checkout the target tag only if the user agrees.
-       e. If the user chooses to stay, continue on the current tag only after explicitly naming both tags.
-  3. Read model/Li+core.md (core layer).
-  4. Read task/Li+issues.md (task layer) — only if hooks are unavailable.
-     When hooks inject constant-load sections per-turn, startup read is redundant.
-  5. Keep operations/Li+github.md available for event-driven reads later.
+- Version check is mandatory on every startup before proceeding to Phase 4.
+- Silent continuation on a stale local clone is prohibited.
 
-7. Bootstrap host adapter:
-- Determine target path and adapter source by runtime:
-  - codex: target = {workspace_root}/AGENTS.md, source = adapter/codex/Li+agent.md
-  - claude: target = {workspace_root}/.claude/CLAUDE.md, source = adapter/claude/Li+agent.md
-- Replace {LI_PLUS_TAG} in all generated content with the resolved target tag from step 6.
+3.2. Resolve source by LI_PLUS_MODE:
+
+api mode:
+- Fetch model/Li+core.md for the target version via GitHub API from LI_PLUS_REPOSITORY.
+- Conditionally fetch task/Li+issues.md (skip if the adapter loads it automatically per-turn).
+
+clone mode:
+1. Target repo is the target version of LI_PLUS_REPOSITORY.
+2. Check workspace for repository directory (derived from LI_PLUS_REPOSITORY name):
+   - not exists -> clone target tag directly to workspace. Proceed to step 3.
+   - exists -> fetch --tags, then:
+     a. Resolve and report both values: current checked-out tag and target tag from LI_PLUS_CHANNEL.
+     b. If same -> continue.
+     c. If different -> ask the user how to proceed before continuing to Phase 4.
+        Do not report bootstrap completion before this choice is resolved.
+        Minimum choices:
+        - update now to the target tag
+        - stay on the current tag for this session
+     d. Checkout the target tag only if the user agrees.
+     e. If the user chooses to stay, continue on the current tag only after explicitly naming both tags.
+3. Source files are now available at the resolved tag. Phase 4 handles reading.
+
+## Phase 4: Host Integration
+
+Dependencies: Phase 3 (source resolved, target tag known).
+
+Runtime-specific integration. Branch by detected runtime.
+
+### Phase 4 claude: Claude Code Integration
+
+Adapter, rules, skills, and hooks generation. Rules/skills generation doubles as layer loading
+(the host reads generated rules/ and skills/ files every turn, so explicit reads are unnecessary).
+
+4c.1. Bootstrap adapter:
+- target = {workspace_root}/.claude/CLAUDE.md, source = adapter/claude/Li+agent.md
+- Replace {LI_PLUS_TAG} in all generated content with the resolved target tag from Phase 3.
 - Adapter section judgment:
   a. If target file does not exist: create it with the contents of the adapter source.
   b. If target file exists and contains "Li+ BEGIN" sentinel:
-     - Extract the tag from the sentinel (e.g. "Li+ BEGIN (build-2026-03-30.14)" → "build-2026-03-30.14").
+     - Extract the tag from the sentinel (e.g. "Li+ BEGIN (build-2026-03-30.14)" -> "build-2026-03-30.14").
      - If extracted tag matches current target tag: skip (up to date).
      - If tag differs or is absent: replace the section between "Li+ BEGIN" and "Li+ END" (inclusive)
        with the current adapter source contents. Preserve content outside this section.
-  c. If target file exists but does not contain "Li+ BEGIN": ask user — append Li+ section or skip?
-- If runtime=claude: bootstrap hooks from adapter/claude/Li+hooks.md.
-  - Read adapter/claude/Li+hooks.md.
-  - If {workspace_root}/.claude/settings.json does not exist or does not contain "PostToolUse":
-    create settings.json and hook scripts from the code blocks in Li+hooks.md.
-  - If settings.json exists and contains "PostToolUse":
-    - Check the source tag in existing hook scripts (e.g. "# Source: Li+hooks.md (build-2026-03-30.14)").
-    - If tag matches current target tag: skip (up to date).
-    - If tag differs or is absent: regenerate hook scripts only (do not overwrite settings.json).
-  - Set executable permission on .sh files.
-- Note: bootstrap takes effect from the NEXT session. Current session continues with Li+config.md execution.
+  c. If target file exists but does not contain "Li+ BEGIN": ask user -- append Li+ section or skip?
 
-7b. Generate .claude/rules/ files (runtime=claude only):
+4c.2. Generate .claude/rules/ files:
 - If {workspace_root}/.claude/rules/ does not exist: create directory.
 - Generate Li+core.md:
   - If file does not exist or source tag differs from current target tag:
@@ -106,7 +119,7 @@ Silent continuation on a stale local clone is prohibited.
   - No tag-based overwrite. User customizations are preserved across updates.
 - Tag detection: check first line for "# Source:" comment or frontmatter containing tag.
 
-7c. Generate .claude/skills/li-plus-issues/SKILL.md (runtime=claude only):
+4c.3. Generate .claude/skills/li-plus-issues/SKILL.md:
 - If {workspace_root}/.claude/skills/li-plus-issues/ does not exist: create directory.
 - If SKILL.md does not exist or source tag differs from current target tag:
   Prepend skill frontmatter (name, description with trigger conditions) to task/Li+issues.md contents.
@@ -115,8 +128,51 @@ Silent continuation on a stale local clone is prohibited.
 - If source tag matches: skip (up to date).
 - Frontmatter template defined in adapter/claude/Li+hooks.md skills/ generation template section.
 
-8. Prepare USER_REPOSITORY working clone (skip if `owner/repository-name`):
+4c.4. Bootstrap hooks:
+- Read adapter/claude/Li+hooks.md.
+- If {workspace_root}/.claude/settings.json does not exist or does not contain "PostToolUse":
+  create settings.json and hook scripts from the code blocks in Li+hooks.md.
+- If settings.json exists and contains "PostToolUse":
+  - Check the source tag in existing hook scripts (e.g. "# Source: Li+hooks.md (build-2026-03-30.14)").
+  - If tag matches current target tag: skip (up to date).
+  - If tag differs or is absent: regenerate hook scripts only (do not overwrite settings.json).
+- Set executable permission on .sh files.
+
+Note: bootstrap takes effect from the NEXT session. Current session continues with Li+config.md execution.
+
+### Phase 4 codex: Codex Integration
+
+Adapter generation and direct layer reads. Codex has no rules/skills mechanism,
+so layers must be read explicitly.
+
+4x.1. Bootstrap adapter:
+- target = {workspace_root}/AGENTS.md, source = adapter/codex/Li+agent.md
+- Replace {LI_PLUS_TAG} in all generated content with the resolved target tag from Phase 3.
+- Adapter section judgment:
+  a. If target file does not exist: create it with the contents of the adapter source.
+  b. If target file exists and contains "Li+ BEGIN" sentinel:
+     - Extract the tag from the sentinel (e.g. "Li+ BEGIN (build-2026-03-30.14)" -> "build-2026-03-30.14").
+     - If extracted tag matches current target tag: skip (up to date).
+     - If tag differs or is absent: replace the section between "Li+ BEGIN" and "Li+ END" (inclusive)
+       with the current adapter source contents. Preserve content outside this section.
+  c. If target file exists but does not contain "Li+ BEGIN": ask user -- append Li+ section or skip?
+
+4x.2. Read Li+ layers directly:
+- Read model/Li+core.md (core layer).
+- Read task/Li+issues.md (task layer) -- only if hooks are unavailable.
+  When hooks inject constant-load sections per-turn, startup read is redundant.
+- Keep operations/Li+github.md available for event-driven reads later.
+
+## Phase 5: Workspace Preparation
+
+Dependencies: Phase 2 (gh CLI authenticated).
+
+5.1. Prepare USER_REPOSITORY working clone (skip if `owner/repository-name`):
 - If USER_REPOSITORY matches LI_PLUS_REPOSITORY: run `git checkout main` in the local clone.
 - Otherwise: clone by repository name to workspace.
 
-9. Report completion.
+## Phase 6: Completion Report
+
+Dependencies: all prior phases.
+
+6.1. Report completion.


### PR DESCRIPTION
Refs #1037

リニアなステップ番号（1-9 + 3b/7b/7c）をフェーズ制に再構成。

- Phase 1: 環境検出 -- ランタイム判定、OSパーミッション
- Phase 2: 認証・設定 -- gh CLI、GH_TOKEN、言語契約、webhook delivery
- Phase 3: Li+ ソース解決 -- チャンネル→タグ決定、clone/fetch + タグ確認
- Phase 4: ホスト統合 -- claude: adapter/rules/skills/hooks生成（層読み込み兼務）; codex: adapter + 直接Read
- Phase 5: ワークスペース準備 -- USER_REPOSITORY clone
- Phase 6: 完了報告

主な改善:
- Claude Code + clone モードで rules/skills 生成が層読み込みを兼ねるため、Phase 3 clone での明示的 Read を除去（二重読み込み解消）
- Step 7/7b/7c の肥大化を Phase 4 のランタイム分岐サブセクションに整理
- 各フェーズに依存関係を明示
- Codex は Phase 4 で直接 Read を維持（rules/skills 機構がないため）