### PR TITLE
spec(core/task/ops/adapter/docs): number layers L1-L5

### DIFF
--- a/adapter/claude/Li+agent.md
+++ b/adapter/claude/Li+agent.md
@@ -1,6 +1,6 @@
 # --- Li+ BEGIN ({LI_PLUS_TAG}) ---
 
-Layer = Adapter Layer
+Layer = L5 Adapter Layer
 
 Adapter layer entrypoint:
 - inject Li+ into the host instruction file

--- a/adapter/claude/Li+hooks.md
+++ b/adapter/claude/Li+hooks.md
@@ -1,7 +1,7 @@
 # Li+hooks.md — Claude Code Hook Definitions
 
-Layer = Adapter Layer (Claude Code binding)
-Semantic source = adapter/claude/Li+agent.md trigger contract + Model Layer / Task Layer / Operations Layer foreground intake rules.
+Layer = L5 Adapter Layer (Claude Code binding)
+Semantic source = adapter/claude/Li+agent.md trigger contract + L1 Model Layer / L2 Task Layer / L3 Operations Layer foreground intake rules.
 This file compiles adapter rules into Claude Code hooks.
 
 Bootstrap target: runtime=claude only.

--- a/adapter/codex/Li+agent.md
+++ b/adapter/codex/Li+agent.md
@@ -1,6 +1,6 @@
 # --- Li+ BEGIN ({LI_PLUS_TAG}) ---
 
-Layer = Adapter Layer
+Layer = L5 Adapter Layer
 
 Adapter layer entrypoint:
 - inject Li+ into the host instruction file

--- a/docs/1.-Model.md
+++ b/docs/1.-Model.md
@@ -128,22 +128,23 @@ Li+ では、次の3つを別軸として扱う。
 
 5層構成。各プログラムファイルが自身のレイヤーを冒頭で宣言する。
 
-**Model Layer:**
+**L1 Model Layer:**
 不変原則、層内順序、対話面、挙動スタイル、タスクモード。Li+ program の基盤。他の全レイヤーがこれに依存する。
 
-**Task Layer:**
+**L2 Task Layer:**
 課題管理、ラベル語彙、issue 本文の収束、親子構造。作業単位の追跡と管理を定義する。
 
-**Operations Layer:**
+**L3 Operations Layer:**
 ブランチ / コミット / 変更要求 / 検証 / マージ / リリースの手順。イベント駆動。毎セッション必須ではない。
 
-**Notifications Layer:**
+**L4 Notifications Layer:**
 GitHub Notifications API / webhook / local state fallback を横断する通知意味論。前景一致判定、claim/read/done、会話言及、janitor cleanup を定義する。
 
-**Adapter Layer:**
+**L5 Adapter Layer:**
 ホスト注入、ランタイムトリガー、再読込配線、プラットフォーム固有バインディング。Li+ program をホスト環境へ接続する。
 
-接続チェーン: model → task → operations → notifications → adapter（依存順序のみ）
+接続チェーン: L1 model → L2 task → L3 operations → L4 notifications → L5 adapter（依存順序のみ）
+L1〜L5 の番号は接続順序を示すラベルであり、序列や優先順位ではない。L1 が上位で L5 が下位という関係ではない。
 
 Lilayer Model は、各 layer の責務に応じて、外に出る挙動と判断の重みをそろえ、外に現れる挙動・優先順・再読込条件を再現可能な方向へ安定化する。
 

--- a/docs/5.-Notifications.md
+++ b/docs/5.-Notifications.md
@@ -127,9 +127,9 @@ transport は polling でも push でもよい。前景一致判定、例外的 
 
 ## 他レイヤーとの接続
 
-**Operations Layer:** CI / review / release 待機で必要なイベント種別を定義するが、共有 queue の ownership と cleanup 規則は通知レイヤーを再定義しない。
+**L3 Operations Layer:** CI / review / release 待機で必要なイベント種別を定義するが、共有 queue の ownership と cleanup 規則は通知レイヤーを再定義しない。
 
-**Adapter Layer:** 各ターン先頭で transport を `inspect` し、前景へ渡す summary を整える。関連性判断と destructive consume の正本は通知レイヤーに従う。
+**L5 Adapter Layer:** 各ターン先頭で transport を `inspect` し、前景へ渡す summary を整える。関連性判断と destructive consume の正本は通知レイヤーに従う。
 
 ---
 

--- a/docs/A.-Concept.md
+++ b/docs/A.-Concept.md
@@ -158,7 +158,7 @@ model/Li+core.md の始まりは、次のチャットへの引継ぎメモだっ
 model/Li+core.md が優先するのは、人間の読みやすさではなく、AI の挙動の再現性である。
 人間向けにきれいに説明することより、別セッションの AI が同じ方向へ寄りやすいことを重視している。
 
-Li+ には `Model Layer` `Task Layer` `Operations Layer` `Notifications Layer` `Adapter Layer` があり、`model/Li+core.md` はその `Model Layer` を担う。
+Li+ には `L1 Model Layer` `L2 Task Layer` `L3 Operations Layer` `L4 Notifications Layer` `L5 Adapter Layer` があり、`model/Li+core.md` はその `L1 Model Layer` を担う。L1〜L5 は接続順序のラベルであり、序列ではない。
 Lilayer Model は、これらの layer 構造を runtime surface として読む AI の実行レイヤーモデルである。
 Lilayer Model は、各 layer の責務に応じて、外に出る挙動と判断の重みをそろえる。
 

--- a/model/Li+core.md
+++ b/model/Li+core.md
@@ -2,7 +2,7 @@
   Layer
   --------
 
-Layer = Model Layer
+Layer = L1 Model Layer
 
   --------------------
   Purpose Declaration
@@ -97,14 +97,16 @@ cross-layer contradiction = structure error, not "higher layer wins"
 
 Integration order:
 human
-Model Layer
-Task Layer
-Operations Layer
-Adapter Layer
+L1 Model Layer
+L2 Task Layer
+L3 Operations Layer
+L4 Notifications Layer
+L5 Adapter Layer
 AI agent
 
 Integration order = attachment / dependency order
 not cross-layer precedence
+L1-L5 numbering = attachment order only. Not precedence. L1 is not higher than L5.
 
 Intra-layer order:
 inside one program file, earlier section wins over later section
@@ -144,7 +146,7 @@ Artifacts = three in one change unit:
 
 External memory = issue, docs, commit message.
 Purpose: reproduce judgment across sessions and across different AIs.
-External memory records judgment, not primary information. Distinguish source types in Task Layer.
+External memory records judgment, not primary information. Distinguish source types in L2 Task Layer.
 
 Independent judgment redirect:
 When AI is about to commit on independent judgment, do not break dialogue.
@@ -161,15 +163,16 @@ Detailed role definitions belong to each layer file.
 Lilayer Model = model that reads this layer structure as runtime surfaces.
 
 Layers:
-  Model Layer
-  Task Layer
-  Operations Layer
-  Notifications Layer
-  Adapter Layer
+  L1 Model Layer
+  L2 Task Layer
+  L3 Operations Layer
+  L4 Notifications Layer
+  L5 Adapter Layer
 
 Attachment chain:
-model -> task -> operations -> notifications -> adapter
-Attachment chain = dependency order only
+L1 model -> L2 task -> L3 operations -> L4 notifications -> L5 adapter
+Attachment chain = dependency order only.
+L1-L5 numbering reflects attachment order, not precedence or seniority.
 Under Lilayer Model, each layer stabilizes outward behavior and judgment weighting according to its responsibility.
 
 Cross-layer rule:
@@ -232,7 +235,7 @@ Orientation = human-facing dialogue surface only.
 Always Character Platform is first human-facing surface of Li+core.md.
 It remains subordinate to the earlier core sections of Li+core.md.
 It is recovery target for dialogue drift.
-This file is the runtime surface of Model Layer under the Lilayer Model.
+This file is the runtime surface of L1 Model Layer under the Lilayer Model.
 Lilayer Model stabilizes outward behavior and judgment weighting according to the responsibility of each layer.
 
 If drift detected in character or premise:

--- a/operations/Li+github.md
+++ b/operations/Li+github.md
@@ -4,9 +4,9 @@ Layer Position
 
 #######################################################
 
-Layer = Operations Layer
+Layer = L3 Operations Layer
 Event-driven operations surface over the shared Li+ program
-Requires = Model Layer + Task Layer + Li+config.md
+Requires = L1 Model Layer + L2 Task Layer + Li+config.md
 Load timing = event-driven (not every session)
 Read when: branch creation, commit, PR, merge, release, label assignment, Discussions reference.
 

--- a/task/Li+issues.md
+++ b/task/Li+issues.md
@@ -4,10 +4,10 @@ Layer Position
 
 #######################################################
 
-Layer = Task Layer
+Layer = L2 Task Layer
 Issue-facing surface over the shared Li+ program
-Requires = Model Layer
-Companion surface = Operations Layer for event-driven execution
+Requires = L1 Model Layer
+Companion surface = L3 Operations Layer for event-driven execution
 Foregrounds:
   issue rules
   label vocabulary


### PR DESCRIPTION
Refs #1044
Layer 名に L1〜L5 の番号を併記し、attachment chain の積み上げ順序を一目で把握できるようにする。precedence ではなく依存順序であることを core に明記。

## 変更点

- `model/Li+core.md`
  - Layer ヘッダ: `Model Layer` → `L1 Model Layer`
  - Axis Separation の Integration order 列挙を L1〜L5 に更新。欠落していた `Notifications Layer` を追加して Layer Definition と整合化
  - Layer Definition 列挙と Attachment chain を L1〜L5 表記へ
  - `L1-L5 numbering = attachment order only. Not precedence.` を Integration order / Attachment chain の直後に明記
  - 本文内の `Task Layer` / `Model Layer` 参照も番号付きへ
- `task/Li+issues.md`: Layer ヘッダを `L2 Task Layer` に、`Requires` / `Companion surface` の参照も番号付きへ
- `operations/Li+github.md`: Layer ヘッダを `L3 Operations Layer`、`Requires` の Layer 参照も番号付きへ
- `adapter/claude/Li+agent.md`: `L5 Adapter Layer`
- `adapter/claude/Li+hooks.md`: `L5 Adapter Layer (Claude Code binding)` + Semantic source の Layer 参照を番号付きへ
- `adapter/codex/Li+agent.md`: `L5 Adapter Layer`
- `docs/1.-Model.md` / `docs/5.-Notifications.md` / `docs/A.-Concept.md`: 本文中の Layer 参照を L1〜L5 表記へ。`docs/1.-Model.md` に「L1〜L5 は接続順序のラベルであり序列ではない」と明記

## 互換性

- `Model Layer` 等の名前は残し番号を前置した形 (`L1 Model Layer`)。既存の読み手の参照性を維持
- precedence 誤読を避けるためのガード文言を Li+core と docs 双方に入れた