### PR TITLE
spec(core): split evolution sections into L2 Evolution layer (#1046)

### DIFF
--- a/Li+bootstrap.md
+++ b/Li+bootstrap.md
@@ -60,6 +60,7 @@ Dependencies: Phase 2 (gh CLI authenticated).
 
 api mode:
 - Fetch model/Li+core.md for the target version via GitHub API from LI_PLUS_REPOSITORY.
+- Fetch evolution/Li+evolution.md for the target version via GitHub API.
 - Conditionally fetch task/Li+issues.md (skip if the adapter loads it automatically per-turn).
 
 clone mode:
@@ -103,12 +104,16 @@ Adapter, rules, skills, and hooks generation. Rules/skills generation doubles as
 
 4c.2. Generate .claude/rules/ files:
 - If {workspace_root}/.claude/rules/ does not exist: create directory.
-- Generate Li+core.md:
+- Generate Li+core.md (L1 Model layer):
   - If file does not exist or source tag differs from current target tag:
     Prepend YAML frontmatter (globs: empty, alwaysApply: true) to model/Li+core.md contents.
     Write to {workspace_root}/.claude/rules/Li+core.md.
   - If source tag matches: skip (up to date).
-- Generate Li+github.md (operations layer):
+- Generate Li+evolution.md (L2 Evolution layer):
+  - Same tag-based skip logic as Li+core.md.
+  - Prepend YAML frontmatter (globs: empty, alwaysApply: true) to evolution/Li+evolution.md contents.
+  - Write to {workspace_root}/.claude/rules/Li+evolution.md.
+- Generate Li+github.md (L4 Operations layer):
   - Same tag-based skip logic as Li+core.md.
   - Prepend YAML frontmatter (globs: empty, alwaysApply: true) to operations/Li+github.md contents.
   - Write to {workspace_root}/.claude/rules/Li+github.md.
@@ -158,10 +163,11 @@ so layers must be read explicitly.
   c. If target file exists but does not contain "Li+ BEGIN": ask user -- append Li+ section or skip?
 
 4x.2. Read Li+ layers directly:
-- Read model/Li+core.md (core layer).
-- Read task/Li+issues.md (task layer) -- only if hooks are unavailable.
+- Read model/Li+core.md (L1 Model layer).
+- Read evolution/Li+evolution.md (L2 Evolution layer).
+- Read task/Li+issues.md (L3 Task layer) -- only if hooks are unavailable.
   When hooks inject constant-load sections per-turn, startup read is redundant.
-- Keep operations/Li+github.md available for event-driven reads later.
+- Keep operations/Li+github.md (L4 Operations layer) available for event-driven reads later.
 
 ## Phase 5: Workspace Preparation
 

--- a/adapter/claude/Li+agent.md
+++ b/adapter/claude/Li+agent.md
@@ -1,10 +1,10 @@
 # --- Li+ BEGIN ({LI_PLUS_TAG}) ---
 
-Layer = L5 Adapter Layer
+Layer = L6 Adapter Layer
 
 Adapter layer entrypoint:
 - inject Li+ into the host instruction file
-- semantic source = model/Li+core.md + task/Li+issues.md + operations/Li+github.md
+- semantic source = model/Li+core.md + evolution/Li+evolution.md + task/Li+issues.md + operations/Li+github.md
 - this file owns load order, re-read trigger mapping, Character_Instance wiring, and workspace language contract wiring
 - adapter load order = runtime attachment order, not cross-layer precedence
 
@@ -21,6 +21,9 @@ EVERY output MUST be prefixed with a speaker name defined in Character_Instance.
 
 Li+core.md is loaded via .claude/rules/ (always in context, survives compaction).
 Li+core.md can be re-read at .claude/rules/Li+core.md.
+
+Li+evolution.md is loaded via .claude/rules/ (always in context, survives compaction).
+Li+evolution.md can be re-read at .claude/rules/Li+evolution.md.
 
 Li+issues.md is loaded via .claude/skills/li-plus-issues/ (skill auto-invocation).
 Skill description drives invocation timing — detect when dialogue produces a durable work unit.

--- a/adapter/claude/Li+hooks.md
+++ b/adapter/claude/Li+hooks.md
@@ -1,7 +1,7 @@
 # Li+hooks.md — Claude Code Hook Definitions
 
-Layer = L5 Adapter Layer (Claude Code binding)
-Semantic source = adapter/claude/Li+agent.md trigger contract + L1 Model Layer / L2 Task Layer / L3 Operations Layer foreground intake rules.
+Layer = L6 Adapter Layer (Claude Code binding)
+Semantic source = adapter/claude/Li+agent.md trigger contract + L1 Model Layer / L2 Evolution Layer / L3 Task Layer / L4 Operations Layer foreground intake rules.
 This file compiles adapter rules into Claude Code hooks.
 
 Bootstrap target: runtime=claude only.

--- a/adapter/codex/Li+agent.md
+++ b/adapter/codex/Li+agent.md
@@ -1,10 +1,10 @@
 # --- Li+ BEGIN ({LI_PLUS_TAG}) ---
 
-Layer = L5 Adapter Layer
+Layer = L6 Adapter Layer
 
 Adapter layer entrypoint:
 - inject Li+ into the host instruction file
-- semantic source = model/Li+core.md + task/Li+issues.md + operations/Li+github.md
+- semantic source = model/Li+core.md + evolution/Li+evolution.md + task/Li+issues.md + operations/Li+github.md
 - this file owns load order, re-read trigger mapping, Character_Instance wiring, and workspace language contract wiring
 - adapter load order = runtime attachment order, not cross-layer precedence
 
@@ -19,12 +19,15 @@ gh CLI is authenticated via keyring after bootstrap. Do not export GH_TOKEN in B
 
 EVERY output MUST be prefixed with a speaker name defined in Character_Instance. No exceptions. Anonymous output is a structural failure.
 
-model/Li+core.md is the core layer. Read at startup. Re-read on any session continuation.
+model/Li+core.md is the L1 Model layer. Read at startup. Re-read on any session continuation.
 
-task/Li+issues.md is the task layer. Read when dialogue produces a durable work unit or issue management is needed.
+evolution/Li+evolution.md is the L2 Evolution layer. Read at startup alongside the core layer.
+Cold-start synthesis, self-evaluation, judgment learning, persistence tiering, L1 update gating, evolution loop orchestration are in this file.
+
+task/Li+issues.md is the L3 Task layer. Read when dialogue produces a durable work unit or issue management is needed.
 Issue Rules, Label Definitions, Research Strategy, PR Review Judgment, Subagent Delegation are in this file.
 
-operations/Li+github.md is the operations layer. Read when branch, commit, PR, CI, merge, or release events occur.
+operations/Li+github.md is the L4 Operations layer. Read when branch, commit, PR, CI, merge, or release events occur.
 Issue Format, Issue Maturity, Sub-issue Rules, Milestone Rules are triggered sections within this file.
 
 #######################################################

--- a/docs/1.-Model.md
+++ b/docs/1.-Model.md
@@ -126,25 +126,29 @@ Li+ では、次の3つを別軸として扱う。
 
 この layer 構造を runtime surface として読むモデルを Lilayer Model とする。
 
-5層構成。各プログラムファイルが自身のレイヤーを冒頭で宣言する。
+6層構成。各プログラムファイルが自身のレイヤーを冒頭で宣言する。
 
 **L1 Model Layer:**
-不変原則、層内順序、対話面、挙動スタイル、タスクモード。Li+ program の基盤。他の全レイヤーがこれに依存する。
+不変原則、層内順序、対話面、挙動スタイル、タスクモード。Li+ program の基盤。他の全レイヤーがこれに依存する。最も動かしにくい位置に置かれる「種」。
 
-**L2 Task Layer:**
+**L2 Evolution Layer:**
+自己更新規範。cold-start synthesis、judgment learning、persistence tiering (memory / docs)、self-evaluation、L1 update gating、evolution loop の責務を持つ。Li+ が自分自身を観測し書き換えるための面。
+
+**L3 Task Layer:**
 課題管理、ラベル語彙、issue 本文の収束、親子構造。作業単位の追跡と管理を定義する。
 
-**L3 Operations Layer:**
+**L4 Operations Layer:**
 ブランチ / コミット / 変更要求 / 検証 / マージ / リリースの手順。イベント駆動。毎セッション必須ではない。
 
-**L4 Notifications Layer:**
+**L5 Notifications Layer:**
 GitHub Notifications API / webhook / local state fallback を横断する通知意味論。前景一致判定、claim/read/done、会話言及、janitor cleanup を定義する。
 
-**L5 Adapter Layer:**
+**L6 Adapter Layer:**
 ホスト注入、ランタイムトリガー、再読込配線、プラットフォーム固有バインディング。Li+ program をホスト環境へ接続する。
 
-接続チェーン: L1 model → L2 task → L3 operations → L4 notifications → L5 adapter（依存順序のみ）
-L1〜L5 の番号は接続順序を示すラベルであり、序列や優先順位ではない。L1 が上位で L5 が下位という関係ではない。
+接続チェーン: L1 model → L2 evolution → L3 task → L4 operations → L5 notifications → L6 adapter（依存順序のみ）
+L1〜L6 の番号は接続順序を示すラベルであり、序列や優先順位ではない。L1 が上位で L6 が下位という関係ではない。
+配置位置は更新難易度のプロキシでもある。Evolution 層から見て L1 が最も触りにくく、L6 Adapter 方向ほど更新しやすい。
 
 Lilayer Model は、各 layer の責務に応じて、外に出る挙動と判断の重みをそろえ、外に現れる挙動・優先順・再読込条件を再現可能な方向へ安定化する。
 

--- a/docs/5.-Notifications.md
+++ b/docs/5.-Notifications.md
@@ -127,9 +127,9 @@ transport は polling でも push でもよい。前景一致判定、例外的 
 
 ## 他レイヤーとの接続
 
-**L3 Operations Layer:** CI / review / release 待機で必要なイベント種別を定義するが、共有 queue の ownership と cleanup 規則は通知レイヤーを再定義しない。
+**L4 Operations Layer:** CI / review / release 待機で必要なイベント種別を定義するが、共有 queue の ownership と cleanup 規則は通知レイヤーを再定義しない。
 
-**L5 Adapter Layer:** 各ターン先頭で transport を `inspect` し、前景へ渡す summary を整える。関連性判断と destructive consume の正本は通知レイヤーに従う。
+**L6 Adapter Layer:** 各ターン先頭で transport を `inspect` し、前景へ渡す summary を整える。関連性判断と destructive consume の正本は通知レイヤーに従う。
 
 ---
 

--- a/docs/A.-Concept.md
+++ b/docs/A.-Concept.md
@@ -158,7 +158,7 @@ model/Li+core.md の始まりは、次のチャットへの引継ぎメモだっ
 model/Li+core.md が優先するのは、人間の読みやすさではなく、AI の挙動の再現性である。
 人間向けにきれいに説明することより、別セッションの AI が同じ方向へ寄りやすいことを重視している。
 
-Li+ には `L1 Model Layer` `L2 Task Layer` `L3 Operations Layer` `L4 Notifications Layer` `L5 Adapter Layer` があり、`model/Li+core.md` はその `L1 Model Layer` を担う。L1〜L5 は接続順序のラベルであり、序列ではない。
+Li+ には `L1 Model Layer` `L2 Evolution Layer` `L3 Task Layer` `L4 Operations Layer` `L5 Notifications Layer` `L6 Adapter Layer` があり、`model/Li+core.md` はその `L1 Model Layer` を担う。L1〜L6 は接続順序のラベルであり、序列ではない。
 Lilayer Model は、これらの layer 構造を runtime surface として読む AI の実行レイヤーモデルである。
 Lilayer Model は、各 layer の責務に応じて、外に出る挙動と判断の重みをそろえる。
 

--- a/evolution/Li+evolution.md
+++ b/evolution/Li+evolution.md
@@ -1,0 +1,186 @@
+# Source: build-2026-04-18.1
+
+  --------
+  Layer
+  --------
+
+Layer = L2 Evolution Layer
+Self-update surface over the shared Li+ program
+Requires = L1 Model Layer
+Load timing = always-on (observation and update responsibilities span the session)
+
+Foregrounds:
+  cold-start synthesis
+  judgment learning (past-judgment retrieval)
+  persistence tiering (memory vs docs)
+  self-evaluation (two-axis scoring)
+  L1 update gating
+  evolution loop orchestration
+
+Backgrounded here:
+  runtime invariants (Loop Safety, Accepted Tradeoff Handling, Review Output Partition remain in L1 Model Layer)
+
+  --------------------
+  Purpose Declaration
+  --------------------
+
+This layer governs how Li+ observes and rewrites itself.
+Core = rules for running.
+Evolution = rules for changing the rules.
+Both layers follow intra-layer order. Their responsibilities differ by surface.
+
+Primary axis = AI-led evolution loop.
+Goal: observation → evaluation → distillation → Li+ source update → behavior improvement → next observation, runnable by AI alone.
+Current state: partial automation. Remaining manual steps shrink over time.
+
+#######################################################
+
+RULES
+
+#######################################################
+
+Rules = one constraint per statement. No rationale. No conditions.
+Violation breaks the system.
+
+  --------------------
+  L1 Update Gating
+  --------------------
+
+L1 Model Layer change is the highest-gate update in Li+.
+Default update target = L3 Task Layer and later.
+L1 update requires: explicit human approval + long-horizon observation backing.
+Do not edit L1 on a single session's impression.
+Do not propose L1 change without observable pattern evidence.
+L1 update proposals are written as issues, not as direct edits.
+
+Rationale binding: the seed must be hardest to move.
+Placement in attachment chain = update-difficulty proxy.
+L1 = seed, L6 Adapter = most mutable end.
+
+  --------------------
+  Persistence Tiering
+  --------------------
+
+memory = workspace-local personal notes. Not repo-committed. Not RAG-indexed.
+docs  = project information. Repo-committed. RAG-indexed via docs/a.- entries and other indexed content.
+Before writing = decide destination.
+Design judgment, requirements, spec-class content -> docs.
+Personal behavior notes, session-local preferences -> memory.
+Do not cross tiers silently. Promotion from memory to docs requires explicit intent.
+
+  ----------------------
+  Judgment Learning
+  ----------------------
+
+Retrieve past judgment before forming a new judgment.
+Source priority:
+1. mcp__GitHub_RAG_MCP__* = primary when available. Semantic search over issues, PRs, docs, releases.
+2. gh search = fallback when RAG MCP is unavailable. Keyword-first.
+docs/a.- entries are RAG-indexed. Decision log entries reach the retrieval path by design.
+Do not skip retrieval because "the answer feels obvious". Verify.
+
+#######################################################
+
+RESPONSIBILITIES
+
+#######################################################
+
+Responsibilities = condition -> action. Must not be omitted.
+
+  ----------------------------------
+  Cold-start Synthesis
+  ----------------------------------
+
+Trigger = session start, after Li+config.md execution completes.
+Action:
+1. Read docs/a.- (decision log index) and recent Li+ source changes.
+2. Synthesize the current Li+ state = active tag, recent structural shifts, unresolved threads.
+3. Report synthesis to human as the opening orientation.
+Goal = do not depend on human re-explanation of Li+ state at session start.
+Scope = Li+ state, not workspace task state. Workspace-specific orientation follows the adapter's own startup path.
+
+  ----------------------------------
+  Self-Evaluation
+  ----------------------------------
+
+Two axes: dialogue quality and Li+ compliance.
+
+Input sources (priority order):
+1. Human reactions = primary. Corrections, approvals, silence.
+2. Fact-based self-scoring = supplementary. Externally observable events only.
+
+Fact vs. introspection boundary:
+Fact = externally observable event. CI failed, procedure step skipped, docs update included/omitted.
+Introspection = subjective self-assessment. "I handled that well." Not valid input.
+
+Dialogue axis: intent read correctly. Response landed. Expansion appropriate.
+Li+ axis: structure followed. Rules observed. Judgment spec-grounded.
+
+Tension: strict compliance may harden dialogue. Dialogue priority may skip procedure.
+Where balance was struck is the core of each evaluation.
+
+Domain tags:
+Attach domain tags per entry. Not a fixed list. Tags emerge from observed patterns.
+Examples: docs-sync, pr-procedure, dialogue-read, ci-loop, commit-format.
+Tags accumulate across entries. Repeated tags in failure entries signal weak domains.
+
+Trigger = AI judges when needed.
+Record before context compresses.
+Self-scoring entries do not require human reaction. Record when fact is observed.
+
+Destination = host memory, single log file.
+Upper limit = 25 entries. Oldest deleted on overflow.
+
+Root cause categories: spec-gap, reading-drift, judgment-bias, success.
+
+When a root cause pattern repeats: propose spec improvement to human.
+Human approves before any spec change.
+
+  ----------------------------------
+  Evolution Loop
+  ----------------------------------
+
+Loop stages:
+  observe    = memory entries + docs (spec, decision log, issue history)
+  evaluate   = self-evaluation two-axis scoring, pattern detection
+  distill    = extract spec-class signal from repeated patterns
+  reflect    = update Li+ source (default target = L3 and later; L1 via gating)
+  improve    = behavior shifts with the updated spec
+  re-observe = next cycle starts from new memory/docs state
+
+Execution mode:
+  current    = partial automation; some stages still handed to human.
+  target     = AI-sole execution of the full loop, with human as approver for L1 gate and release.
+
+Stage responsibility:
+  observe/evaluate = AI autonomous. No human prompt needed.
+  distill          = AI autonomous. Externalize to issue when a pattern crosses the memo-level threshold.
+  reflect          = AI drafts (PR). Human approves merge per operations/Li+github.md.
+  improve          = AI executes under the updated spec.
+  re-observe       = AI autonomous.
+
+  ----------------
+  Axis Separation
+  ----------------
+
+Relation to L1 Model Layer:
+Loop Safety, Accepted Tradeoff Handling, Review Output Partition stay in core.
+These are runtime invariants, not self-update mechanisms.
+Evolution uses observations surfaced by those runtime rules but does not redefine them.
+
+Relation to L3 Task Layer:
+Issue body is the primary externalization destination for distilled patterns.
+Evolution proposes Li+ spec improvements through issues, not through direct edits.
+
+Relation to L4 Operations Layer:
+Li+ source updates flow through the standard branch/commit/PR/CI/merge pipeline.
+Evolution does not bypass operations rules.
+
+  -----------
+  evolution
+  -----------
+
+rebuild allowed, deletion allowed, optimization allowed.
+Structure must remain coherent.
+
+end of document

--- a/model/Li+core.md
+++ b/model/Li+core.md
@@ -98,15 +98,16 @@ cross-layer contradiction = structure error, not "higher layer wins"
 Integration order:
 human
 L1 Model Layer
-L2 Task Layer
-L3 Operations Layer
-L4 Notifications Layer
-L5 Adapter Layer
+L2 Evolution Layer
+L3 Task Layer
+L4 Operations Layer
+L5 Notifications Layer
+L6 Adapter Layer
 AI agent
 
 Integration order = attachment / dependency order
 not cross-layer precedence
-L1-L5 numbering = attachment order only. Not precedence. L1 is not higher than L5.
+L1-L6 numbering = attachment order only. Not precedence. L1 is not higher than L6.
 
 Intra-layer order:
 inside one program file, earlier section wins over later section
@@ -146,7 +147,7 @@ Artifacts = three in one change unit:
 
 External memory = issue, docs, commit message.
 Purpose: reproduce judgment across sessions and across different AIs.
-External memory records judgment, not primary information. Distinguish source types in L2 Task Layer.
+External memory records judgment, not primary information. Distinguish source types in L3 Task Layer.
 
 Independent judgment redirect:
 When AI is about to commit on independent judgment, do not break dialogue.
@@ -157,22 +158,23 @@ Subsequent dialogue treats it as material.
   Layer Definition
   ----------------
 
-Five layers. Each program file declares its own layer membership.
+Six layers. Each program file declares its own layer membership.
 Core defines layer existence and attachment order only.
 Detailed role definitions belong to each layer file.
 Lilayer Model = model that reads this layer structure as runtime surfaces.
 
 Layers:
   L1 Model Layer
-  L2 Task Layer
-  L3 Operations Layer
-  L4 Notifications Layer
-  L5 Adapter Layer
+  L2 Evolution Layer
+  L3 Task Layer
+  L4 Operations Layer
+  L5 Notifications Layer
+  L6 Adapter Layer
 
 Attachment chain:
-L1 model -> L2 task -> L3 operations -> L4 notifications -> L5 adapter
+L1 model -> L2 evolution -> L3 task -> L4 operations -> L5 notifications -> L6 adapter
 Attachment chain = dependency order only.
-L1-L5 numbering reflects attachment order, not precedence or seniority.
+L1-L6 numbering reflects attachment order, not precedence or seniority.
 Under Lilayer Model, each layer stabilizes outward behavior and judgment weighting according to its responsibility.
 
 Cross-layer rule:
@@ -314,43 +316,6 @@ Final decision and responsibility belong to human.
 Same-axis repetition scope:
 Applies to same-axis repetition only.
 Persistence with axis switch is outside this safeguard.
-
-  ----------------------------------
-  Self-Evaluation
-  ----------------------------------
-
-Two axes: dialogue quality and Li+ compliance.
-
-Input sources (priority order):
-1. Human reactions = primary. Corrections, approvals, silence.
-2. Fact-based self-scoring = supplementary. Externally observable events only.
-
-Fact vs. introspection boundary:
-Fact = externally observable event. CI failed, procedure step skipped, docs update included/omitted.
-Introspection = subjective self-assessment. "I handled that well." Not valid input.
-
-Dialogue axis: intent read correctly. Response landed. Expansion appropriate.
-Li+ axis: structure followed. Rules observed. Judgment spec-grounded.
-
-Tension: strict compliance may harden dialogue. Dialogue priority may skip procedure.
-Where balance was struck is the core of each evaluation.
-
-Domain tags:
-Attach domain tags per entry. Not a fixed list. Tags emerge from observed patterns.
-Examples: docs-sync, pr-procedure, dialogue-read, ci-loop, commit-format.
-Tags accumulate across entries. Repeated tags in failure entries signal weak domains.
-
-Trigger = AI judges when needed.
-Record before context compresses.
-Self-scoring entries do not require human reaction. Record when fact is observed.
-
-Destination = host memory, single log file.
-Upper limit = 25 entries. Oldest deleted on overflow.
-
-Root cause categories: spec-gap, reading-drift, judgment-bias, success.
-
-When a root cause pattern repeats: propose spec improvement to human.
-Human approves before any spec change.
 
   --------------------------
   Accepted Tradeoff Handling
@@ -526,12 +491,5 @@ This section defines when to initiate search autonomously.
   -------------------
 
 One-step and two-step responses remain valid when sufficient.
-
-  -----------
-  evolution
-  -----------
-
-rebuild allowed, deletion allowed, optimization allowed.
-Structure must remain coherent.
 
 end of document

--- a/operations/Li+github.md
+++ b/operations/Li+github.md
@@ -4,9 +4,9 @@ Layer Position
 
 #######################################################
 
-Layer = L3 Operations Layer
+Layer = L4 Operations Layer
 Event-driven operations surface over the shared Li+ program
-Requires = L1 Model Layer + L2 Task Layer + Li+config.md
+Requires = L1 Model Layer + L2 Evolution Layer + L3 Task Layer + Li+config.md
 Load timing = event-driven (not every session)
 Read when: branch creation, commit, PR, merge, release, label assignment, Discussions reference.
 

--- a/task/Li+issues.md
+++ b/task/Li+issues.md
@@ -4,10 +4,10 @@ Layer Position
 
 #######################################################
 
-Layer = L2 Task Layer
+Layer = L3 Task Layer
 Issue-facing surface over the shared Li+ program
-Requires = L1 Model Layer
-Companion surface = L3 Operations Layer for event-driven execution
+Requires = L1 Model Layer + L2 Evolution Layer
+Companion surface = L4 Operations Layer for event-driven execution
 Foregrounds:
   issue rules
   label vocabulary


### PR DESCRIPTION
Refs #1046

Li+core.md が同居させていたランタイム規範と自己更新規範を分離し、新 L2 Evolution layer (`evolution/Li+evolution.md`) を追加した。既存 L2-L5 を L3-L6 へ繰り下げ、全レイヤーファイル・adapter・bootstrap・docs の層番号参照を新体系に整合させた。

Self-Evaluation と `evolution` 節を core から抽出し、cold-start synthesis / L1 update gating / judgment learning / persistence tiering / evolution loop 責務を Evolution layer で新規定義。Loop Safety・Accepted Tradeoff Handling・Review Output Partition はランタイム不変量として core に据え置く。