### PR TITLE
spec(ops): add git identity step to wiki sync procedure (#1050)

### DIFF
--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -299,6 +299,27 @@ gh release list --limit 1  # プレリリースを含む
 
 CD workflow がタグを作成するプロジェクトでは、既存の CD 作成タグを使い、新規タグを作らない。npm version を使うプロジェクトでは、npm version コマンドがタグを作成する。
 
+#### リリース後の Wiki 同期
+
+`docs/` は正本、Wiki は反映先。リリース公開後、Wiki を `docs/` の完全ミラーとして更新する。rename や削除があったページが Wiki に残留しないよう、毎回既存 markdown を削除してから置き直す。
+
+手順：
+
+```
+1. Wiki リポジトリを clone: git clone https://github.com/{owner}/{repo}.wiki.git {tmpdir}
+2. identity 設定（clone-and-throw-away パターンのため明示設定が必要）:
+   git -C {tmpdir} config user.name  "{commit-author-name}"
+   git -C {tmpdir} config user.email "{commit-author-email}"
+3. 既存 markdown を削除（rename/削除ページの残留を防ぐ）: rm -f {tmpdir}/*.md
+4. docs/ をコピー: cp docs/*.md {tmpdir}/
+5. 追加・削除を全てステージング: git -C {tmpdir} add -A
+6. コミット: git -C {tmpdir} commit -m "sync: docs → wiki ({release_tag})"
+7. push: git -C {tmpdir} push
+8. 後片付け: rm -rf {tmpdir}
+```
+
+push が権限等で失敗した場合は人間にエスカレートする。省略は禁止。Wiki 同期はリリース手順の一部であり、後続タスクに分離しない。
+
 ---
 
 ## 責務（追加）

--- a/operations/Li+github.md
+++ b/operations/Li+github.md
@@ -335,12 +335,15 @@ Event-Driven Operations
   Wiki must be a complete mirror of docs/. Renamed or removed pages must disappear from Wiki.
   Steps:
     1. Clone wiki repo: git clone https://github.com/{owner}/{repo}.wiki.git {tmpdir}
-    2. Wipe existing markdown (prevents stale pages from rename/delete): rm -f {tmpdir}/*.md
-    3. Copy docs/ files: cp docs/*.md {tmpdir}/
-    4. Stage all (including deletions): git -C {tmpdir} add -A
-    5. Commit: git -C {tmpdir} commit -m "sync: docs → wiki ({release_tag})"
-    6. Push: git -C {tmpdir} push
-    7. Cleanup: rm -rf {tmpdir}
+    2. Configure identity (clone-and-throw-away pattern requires explicit identity):
+       git -C {tmpdir} config user.name  "{commit-author-name}"
+       git -C {tmpdir} config user.email "{commit-author-email}"
+    3. Wipe existing markdown (prevents stale pages from rename/delete): rm -f {tmpdir}/*.md
+    4. Copy docs/ files: cp docs/*.md {tmpdir}/
+    5. Stage all (including deletions): git -C {tmpdir} add -A
+    6. Commit: git -C {tmpdir} commit -m "sync: docs → wiki ({release_tag})"
+    7. Push: git -C {tmpdir} push
+    8. Cleanup: rm -rf {tmpdir}
   If push fails (permission): escalate to human. Do not skip.
   Wiki sync is part of the release procedure, not a follow-up task.
 


### PR DESCRIPTION
Refs #1050

Post-release wiki sync 手順に git identity 設定ステップを step 2 として挿入し、以降の番号を繰り下げ。clone-and-throw-away パターンの wiki repo は global git config 未設定環境で初回 commit が `unable to auto-detect email address` で失敗するため、手順内に明示する。

v1.12.7 の初実戦で発見した spec gap の follow-up。Evolution loop (観測 → 評価 → spec 反映) の初期事例。