### PR TITLE
spec(release): coarsen version types and separate state axis

### DIFF
--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -54,8 +54,9 @@ Issue Format、Issue Maturity、Sub-issue Rules、Milestone Rules は task/Li+is
 - リリース後の Wiki 同期は必須。省略は禁止
 - 要求仕様書は実装後のフォローアップではない。実装前に作成・更新する
 - PR タイトルには変更の影響範囲を含める
-- AI が作成するリリースは必ずプレリリースとする
-- latest への昇格は人間が判断する
+- AI の `gh release create` デフォルトは state フラグなし（prerelease=false、latest=false）
+- prerelease フラグは AI の裁量オプション。明示的なテスト期間を取りたい時のみ付与する。タグ名は最終形のまま（alpha.N / rc.N / -pre などの suffix は付けない）。昇格時はフラグを外すだけでタグは作り直さない
+- latest フラグは人間専用。実機検証後に `gh release edit {tag} --latest=true` で人間が flip する
 - リリース body は GitHub generated release notes を使う（`--generate-notes` を渡す。`--notes ""` で空 body を渡さない）
 - `mark_processed` は消費した全 webhook イベントに対して必須。省略すると backlog が蓄積する
 
@@ -271,18 +272,30 @@ mcp__github-webhook-mcp が利用可能な場合：
 
 v0.x.x は初期開発版。何でも変わりうる。v1.0.0 以降が正式版（semver 準拠）。
 
+判断軸は「変更の規模」と「user/system から観測できるか」の2つ。
+
 | バージョン | 適用条件 | 判断者 |
 |------------|----------|--------|
-| patch | 構造/API が変わらない変更（修正・明確化・ルール追加） | AI が提案 |
-| minor | 構造/API が変わる変更（再構成・新セクション・アーキテクチャ変更） | AI が提案、人間が承認 |
-| major | 利用者に大きな影響を与える変更（破壊的変更、フェーズ移行、UX刷新など） | 人間が判断 |
+| patch | それ以外すべて（docs / 小 fix / 小 spec / config / 内部ルール変更 / user/system から観測できない governance 構造変更） | AI が提案 |
+| minor | 大きな refactor または大きな構造変更であり、かつ user/system から観測できる | AI が提案、人間が承認 |
+| major | 大規模変更または大きな目標達成（フェーズ移行、プロジェクト節目） | 人間が判断 |
 
-AI は patch または minor を提案する。人間がバージョン種別を最終決定し、AI が実行する。バージョン番号はプレリリースを含む直近のリリースを基準にする。
+**重要な注記：** 「構造変更 → minor」ではない。「構造変更**かつ user/system observable** → minor」。governance や spec rule の変更は、構造的には大きくても観測できなければ patch で扱う。本 issue (#1087) 自身がその典型で、release rule の再設計は governance 構造の変更だが Li+ ユーザーの surface から見えないため patch で ship する。
+
+AI は patch または minor を提案する。minor / major の採用は人間が確認し、AI が実行する。バージョン番号はプレリリースを含む直近のリリースを基準にする。
+
+#### リリース state ルール（バージョン種別とは独立した軸）
+
+state は version type（patch / minor / major）に依存しない独立 axis として扱う。
+
+| state | 既定値と意味 | 操作者 |
+|-------|--------------|--------|
+| default（state フラグなし） | `gh release create` の既定。`prerelease=false`、`latest=false`。version type に関係なく AI はこの default で出す | AI |
+| prerelease | AI が明示的にテスト期間を取りたい時のみ付与する裁量フラグ。タグ名は最終形のまま（alpha.N / rc.N / -pre などの suffix は付けない）。昇格時はフラグを外すだけでタグは作り直さない | AI |
+| latest | 実機検証済みを示す。version type（patch / minor / major）に関係なく実機テストが gate。`gh release edit {tag} --latest=true` で flip | 人間のみ |
 
 #### リリースルール
 
-- AI が作成するリリースは必ずプレリリースとする
-- latest への昇格は実機テスト後に人間が判断する
 - リリースタグ・タイトルはプロジェクト固有の規約に従う
 - リリース body は GitHub generated release notes を使う（`--generate-notes` を渡す。`--notes ""` で空 body を渡さない）
 

--- a/operations/Li+github.md
+++ b/operations/Li+github.md
@@ -59,8 +59,9 @@ Event-Driven Operations
   Requirements spec is not post-implementation follow-up.
   Before implementation starts = create or update corresponding requirements spec first.
   PR title must include impact scope.
-  AI-created release is always prerelease.
-  Latest promotion requires human judgment.
+  AI `gh release create` default = no state flag (prerelease=false, latest=false).
+  prerelease flag = AI option. Use only when an explicit test period is desired. Tag name stays final-form; no alpha/rc/-pre suffix. Promotion strips the flag, not the tag.
+  latest flag = human-only. Set via `gh release edit {tag} --latest=true` after real-device verification.
   Release body = GitHub generated release notes. Pass --generate-notes. Do not pass empty body via --notes "".
   mark_processed is mandatory for every consumed webhook event. Omission causes backlog accumulation.
 
@@ -333,10 +334,17 @@ Event-Driven Operations
   Release version rule:
   v0.x.x = initial development. Anything may change. Not a stable release.
   v1.0.0 = first stable release (semver compliant).
-  patch = change that does not alter structure or API (fix / clarify / add rule)
-  minor = change that alters structure or API (restructure / new section / architectural change)
-  major = change with large impact on users. Human decides. Examples: breaking change, phase transition, UX overhaul.
-  AI proposes patch or minor. Human decides version type. AI executes.
+  Judgment axis = change scale + user/system observability.
+  patch = everything else (docs / small fix / small spec / config / internal rule / governance structure change with no user/system observable impact). This issue (#1087) is itself a patch example: release-rule redesign is structurally governance but not observable from a Li+ user's surface.
+  minor = large refactor or large structural change that is user/system observable.
+  major = large-scale change or major goal milestone (phase transition, project milestone). Human decides.
+  Important note: "structural change -> minor" is wrong. "Structural change AND user/system observable -> minor". Governance / spec rule changes without observable impact stay patch regardless of structural scale.
+  AI proposes patch or minor. Human confirms minor or major. AI executes.
+
+  Release state rule (independent axis from version type):
+  default = no state flag. prerelease=false, latest=false. This is the AI `gh release create` default for any version type.
+  prerelease = AI option. Apply only when an explicit test period is wanted. Tag name is final-form; do not append alpha.N / rc.N / -pre suffix. Promotion = strip flag (`gh release edit {tag} --prerelease=false`), keep the same tag.
+  latest = human-only. Real-device verification gate. Human flips via `gh release edit {tag} --latest=true`. Independent of version type: patch / minor / major all gate on the same real-device check.
 
   Version base rule:
   Base on most recent release = includes prereleases.


### PR DESCRIPTION
Closes #1087

liplus-language の release 判断ルールを再設計し、version type と state を独立 axis に分離した。version type は「変更の規模」と「user/system observable か」の2軸判断に粗化し、state フラグは AI `gh release create` の既定を「state なし」に変更。`AI-created release is always prerelease` ルールを撤廃し、latest は実機検証済みの human-only ゲートとして明確化した。

本 PR 自身は governance 構造の再設計だが Li+ ユーザーの surface からは観測できないため、新ルール下では patch に該当する（マージ後の次回 release が dogfood 1 周目）。