### PR TITLE
spec(operations): relax auto-mode merge strategy confirmation

### DIFF
--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -231,7 +231,15 @@ gh pr view {pr} -R {owner}/{repo} --json mergeStateStatus --jq '.mergeStateStatu
 
 execution_mode == trigger かつ PR 作成時に auto-merge が有効化されている場合、レビュー承認後に GitHub が自動的にスカッシュマージとブランチ削除を処理する。
 
-#### それ以外のマージフロー（auto モード、または auto-merge が利用不可の場合）
+#### auto モードのマージフロー
+
+既定のマージ戦略は `squash`（リポジトリの慣例に従う）。AI が squash 以外を選ぶ必要があると判断した場合のみ人間に確認する（pause して確認）。
+
+```
+gh pr merge {pr} -R {owner}/{repo} --squash
+```
+
+#### trigger モードで auto-merge が利用不可の場合
 
 マージ戦略（squash / merge / rebase）を人間に確認してから実行する。
 

--- a/operations/Li+github.md
+++ b/operations/Li+github.md
@@ -299,7 +299,12 @@ Event-Driven Operations
   if execution_mode == trigger and auto-merge was enabled at PR creation:
     GitHub merges automatically on approval.
 
-  Otherwise (auto mode, or auto-merge unavailable):
+  if execution_mode == auto:
+    Default merge strategy = squash (repo convention).
+    1 = gh pr merge {pr} -R {owner}/{repo} --squash
+    Confirm with human only when AI judges a deviation from squash is necessary (pause and ask).
+
+  if execution_mode == trigger and auto-merge unavailable:
   1 = confirm merge strategy with human (squash / merge / rebase)
   2 = gh pr merge {pr} -R {owner}/{repo} --{strategy}
 


### PR DESCRIPTION
Closes #1084

auto モードのマージ戦略確認 rule を緩和し、squash default + deviation 時のみ human 確認 とした。
trigger モードで auto-merge が利用不可の場合の確認フローは維持。
対象は `operations/Li+github.md` [Merge] と `docs/4.-Operations.md` の文言のみで、既存挙動・既存 issue/PR には影響しない。