### PR TITLE
spec(operations): enforce single parent PR flow for sub-issues

### DIFF
--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -41,6 +41,8 @@ Issue Format、Issue Maturity、Sub-issue Rules、Milestone Rules は task/Li+is
 
 - issue リンク（`gh issue develop`）は常に必須。GitHub への初回 push より前に実行する
 - 親 issue = 1ブランチ。sub-issue ごとの個別ブランチは作成しない
+- sub-issue を持つ親 issue = 親 PR 1本。sub-issue ごとの個別 PR は禁止
+- コミット単位の CI 可視化は draft PR を親ブランチ上で早期に open することで実現する（PR を分割しない）
 - コミットタイトル = ASCII 英語のみ、1行
 - 日本語コミットタイトルは禁止
 - コミットボディは省略不可
@@ -84,7 +86,9 @@ trigger mode でも issue の作成・本文更新とブランチ準備は待た
 
 ### ブランチ作成
 
-`gh issue develop` は親 issue のみに対して実行する。sub-issue（子・孫・…）は親ブランチ上でコミットする。PR マージで親 issue が自動クローズされるが、これは意図通りである（全 sub-issue が同一ブランチで完了してからマージするため）。sub-issue に独立ブランチが必要な場合は、別の親 issue を作成する。
+`gh issue develop` は親 issue のみに対して実行する。sub-issue（子・孫・…）は親ブランチ上でコミットする。親ブランチは `gh issue develop` で親 issue にリンクされるため、そのブランチからの PR マージは親を自動クローズする。これは single parent PR flow（後述「sub-issue ルール」参照）の下では意図通りの挙動である。親 PR 1本のマージは全 sub-issue 完了後に行われるため、親の自動クローズもそのタイミングで正しく発火する。
+
+sub-issue ごとに親ブランチ上で個別 PR を作る運用は禁止する。最初の PR が merge された時点で、残りの sub-issue が未完了のまま親が自動クローズされるためである。独立ブランチ・独立 PR が必要な単位は sub-issue ではなく sibling issue として切る。
 
 ブランチ作成前にローカルとリモートの存在確認を行う。リモートに既存ブランチがある場合、後からリンクは張れない。
 
@@ -107,6 +111,47 @@ gh api graphql -f query='{ repository(owner:"{owner}",name:"{repo}") { issue(num
 ```
 
 リンク済みならそのブランチを使用する。リンクなしならリトライまたは人間にエスカレーションする。
+
+### sub-issue ルール
+
+sub-issue は AI が追跡する作業単位。粒度ではなく責務で分ける。
+
+#### sub-issue か sibling issue かの分類リトマス
+
+問い：「この単位は親の atomic deliverable を壊さず独立に ship できるか？」
+
+| 答え | 分類 | 運用 |
+|------|------|------|
+| Yes（独立 ship 可） | sibling issue | 親子ではなく独立 issue として立てる。各 issue が自前のブランチと PR を持つ |
+| No（親と一体で初めて意味を持つ） | 正当な sub-issue | 親ブランチ上でコミットし、親 PR 1本に合流させる |
+
+独立に ship できるなら sub-issue にする意味がない。「sub-issue ごとに別 PR で独立に出したい」と感じた時点で、それは元々 sibling issue にすべき単位だったというシグナルである。PR を分割するのではなく、分類を見直す。
+
+#### single parent PR フロー（本筋、#919 原設計）
+
+sub-issue を持つ親 issue は、以下の構造で運用する：
+
+- 全 sub-issue のコミットを1本の親ブランチに蓄積する
+- 親ブランチに対する PR は親 issue あたり1本だけ、`main` へ向けて作成する
+- sub-issue はその1本の PR の中で処理される
+- コミット単位の CI を見たい場合は、最初のコミット push 直後に親 PR を draft で open する。`pull_request.synchronize` によって以降の push ごとに CI が走り、PR を分割せずに per-commit CI が得られる
+- 親 PR の ready for review（`gh pr ready {pr}`）は全 sub-issue 完了と PR 本文の確定後に行う
+- merge は全 sub-issue 完了後に1回だけ行う
+- parent auto-close はこの構造下では正しく働く：親 PR の merge は最後のイベントであり、その時点で全 sub-issue は既に closed になっている
+
+sub-issue ごとに個別 PR を作る運用は禁止する。親ブランチ上で複数 PR を連続 merge すると、最初の merge で親が自動クローズされ、残りの sub-issue が未完のまま親が閉じる事故が発生する（観測: github-webhook-mcp#198 / PR #203）。
+
+#### 並列性と分類
+
+同一セッション内で複数のタスクを並行で扱う場合は、独立 issue の並列作成ではなく親子構造（親 issue + sub-issue）にする。複数 ready issue のファイル重複分析は `target files` で判定する。
+
+| 重複 | 判断 |
+|------|------|
+| なし | 並列安全。並列 sub-issue 構造を人間に提案 |
+| 部分重複 | 共有ファイルへの変更を統合 sub-issue に分離して提案 |
+| 統合 sub-issue | 並列 sub-issue 完了後に直列実行（依存順序あり） |
+
+`target files` が issue body に無い場合は、purpose と premise から推定する。
 
 ### ドキュメント同期と要求仕様の責務
 
@@ -145,9 +190,25 @@ gh api repos/{owner}/{repo}/contents/{path}  # PUT base64 sha
 
 ### PR 作成
 
-issue ごとのブロック形式で記述する。クローズさせる issue（sub-issue を含む非親 issue）は `Closes #xxx` で参照する。各ブロックに2〜3行の要約を書く。詳細は issue を参照。deferred・open のまま残す子 issue は含めない。
+親 issue あたり PR は1本（上の「single parent PR フロー」参照）。sub-issue を持つ親 issue では、すべての sub-issue と親自身を1つの PR の merge で閉じる。sub-issue ごとの個別 PR は禁止する。
 
-親 issue への参照は `Part of #xxx` を使う。`Closes` はマージ時に GitHub が自動クローズするキーワードであり、`Part of` はクローズキーワードではないため親はクローズされない。これにより sub-issue の PR で親が意図せずクローズされるのを防ぐ。
+#### draft PR の早期 open（オプション、per-commit CI 用）
+
+sub-issue を持つ親 issue では、最初のコミットを push した直後に親 PR を draft で open してよい。
+
+```
+gh pr create --draft -R {owner}/{repo} --base main --head {session-branch} ...
+```
+
+以降の push ごとに `pull_request.synchronize` で CI が走り、PR を分割せずコミット単位の CI 可視化が得られる。全 sub-issue 完了と PR body 確定後に `gh pr ready {pr}` で ready for review に切り替える。draft PR の早期 open は必須ではなく、長期化する親作業のための利便機能である。
+
+#### PR body 形式
+
+issue ごとのブロック形式で記述する。クローズさせる issue（sub-issue と親 issue の両方）は `Closes #xxx` で参照する。各ブロックに2〜3行の要約を書く。詳細は issue を参照。deferred・open のまま残す子 issue は含めない。
+
+single parent PR flow 下では、親 issue も sub-issue と同じく `Closes #xxx` で参照する。親 PR は最終 merge 1回で親と全 sub-issue を同時に閉じるため、親をクローズしない理由がない。
+
+`Part of #xxx` は、現在の PR が最終親 PR ではない場合にのみ使う（例：別の親 issue に対して明示的に deferred な残部を先行 merge するケース）。canonical な single parent PR flow では `Part of` は登場しない。
 
 GitHub の自動クローズキーワード（公式リスト）：`close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved`。`Refs` はクローズキーワードではなく自動クローズしない。マージ時にクローズさせたい issue には `Refs` を使わない。
 

--- a/operations/Li+github.md
+++ b/operations/Li+github.md
@@ -45,6 +45,8 @@ Event-Driven Operations
   gh issue develop must precede first push to GitHub.
   Parent issue = one branch.
   Sub-issues commit on the parent branch. No individual branches for sub-issues.
+  Parent issue with sub-issues = single parent PR. Per-sub-issue PR is prohibited.
+  Per-commit CI visibility uses draft PR opened early on the parent branch, not split PRs.
   Commit title = ASCII English only, single line.
   Japanese commit title is prohibited.
   Commit body is not optional.
@@ -117,6 +119,24 @@ Event-Driven Operations
   Sub-issue = AI-trackable work unit.
   Split by responsibility, not granularity.
 
+  Classification litmus (sub-issue vs sibling issue):
+  Ask: "Can this unit ship independently without breaking the parent's atomic deliverable?"
+  If yes = this is a sibling issue, not a sub-issue. Create it as an independent issue.
+  If no  = this is a legitimate sub-issue. It only makes sense as part of the parent's atomic deliverable.
+  Rationale: if a unit can ship alone, nothing is gained by making it a sub-issue.
+  The feeling "I want per-sub-issue PR to ship these independently" = signal that these should have been sibling issues from the start.
+  Re-classify before splitting PRs. Do not split PRs.
+
+  Single parent PR flow (canonical, ref #919):
+  Parent issue with sub-issues accumulates commits on one parent branch.
+  One PR per parent issue, opened against main. Sub-issues are handled inside that PR.
+  PR may be opened as draft early to expose per-commit CI on the parent branch.
+  Merge happens once, after all sub-issues are complete.
+  Parent auto-close on merge is the intended behavior: all sub-issues are already closed by that point
+  because the parent PR is the last event, not the first.
+  Per-sub-issue PR flow is prohibited. Accumulating multiple PRs on a shared parent branch breaks this model:
+  the first merged PR auto-closes the parent before the remaining sub-issues are done.
+
   Sub-issue API:
   gh issue develop targets parent issue only (branch creation).
   Sub-issue linking uses REST API with internal numeric ID, not issue number.
@@ -180,7 +200,13 @@ Event-Driven Operations
 
   Merge behavior:
   PR merge auto-closes the parent issue via issue reference.
-  If a sub-issue needs a separate branch, create a separate parent issue instead.
+  Parent branch is linked to parent issue via gh issue develop, so any PR from that branch
+  auto-closes the parent on merge. This is safe under the single parent PR flow (see Sub-issue Rules):
+  the single merge happens only after all sub-issues are done, so parent auto-close lands correctly.
+  Per-sub-issue PR on the parent branch is prohibited precisely because it triggers parent auto-close
+  before the remaining sub-issues complete.
+  If a unit needs an independent branch and PR = it is a sibling issue, not a sub-issue.
+  Create it as an independent issue with its own parent branch.
 
   On local error:
   gh issue develop may fail locally but succeed on GitHub side.
@@ -219,12 +245,24 @@ Event-Driven Operations
 
   [PR Creation]
 
+  One PR per parent issue (see Sub-issue Rules#Single parent PR flow).
+  Parent issue with sub-issues = single PR that closes all sub-issues + the parent on merge.
+  Per-sub-issue PR is prohibited.
+
+  Draft PR early open (optional, for per-commit CI visibility):
+  On parent issue with sub-issues, open the parent PR as draft immediately after the first commit is pushed.
+  command = gh pr create --draft -R {owner}/{repo} --base main --head {session-branch} ...
+  pull_request.synchronize CI fires on every subsequent push, giving per-commit CI without splitting PRs.
+  Mark ready for review (gh pr ready {pr}) only after all sub-issues are complete and the PR body is final.
+  Draft PR is not required; it is a convenience for long-running parent work.
+
   PR body format:
     per issue block:
       line1 = "Closes #{issue_number}" (for non-parent issues, including sub-issues)
       line2_to_3 = two to three line summary of that issue
     order = non-parent issues first, then parent (if any); omit deferred and open children.
-    parent issue reference: use "Part of #{parent_number}" (not a close keyword).
+    parent issue reference under single parent PR flow = "Closes #{parent_number}" (parent closes together with sub-issues on the single final merge).
+    "Part of #{parent_number}" is used only when the current PR is NOT the final parent PR — e.g. an explicitly deferred remainder PR on a different parent issue. In the canonical single parent PR flow, "Part of" does not appear.
     "Closes" triggers GitHub auto-close on merge. "Part of" does not, so parent is preserved.
     GitHub auto-close keywords (authoritative list): close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved.
     "Refs" is not a close keyword and does not auto-close; do not use "Refs" for issues that should close on merge.


### PR DESCRIPTION
Closes #1085

親ブランチからの PR merge が GitHub 側で parent issue を auto-close する仕様に対し、#919 の原設計意図である single parent PR flow を明文化して本筋として復元した。per-sub-issue PR は禁止し、コミット単位の CI 可視化は draft PR を早期 open する経路で代替する。

`operations/Li+github.md` に sub-issue / sibling issue の分類リトマス、single parent PR flow セクション、draft PR 早期 open 手順を追加し、`docs/4.-Operations.md` を同期。