### PR TITLE
spec(execution-mode): add semi_auto mode with type-gated human check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# すべてのファイルに @smileygames のレビューを必須とする
-* @smileygames

--- a/Li+config.md
+++ b/Li+config.md
@@ -6,7 +6,7 @@ GH_TOKEN=github_pat_XXXX
 
 ### あなたのプロジェクトリポジトリ
 USER_REPOSITORY=owner/repository-name
-### 実行モード: trigger（人間主導）または auto（AI自律）
+### 実行モード: trigger（人間主導）/ semi_auto（patch は AI 自律、minor/major は人間確認）/ auto（AI 自律）
 ### 未設定の場合、セッション開始時にAIが聞いて自動設定します
 # USER_REPOSITORY_EXECUTION_MODE=trigger
 

--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -258,8 +258,20 @@ CI FAIL → 修正してリコミット（CI ループを step 1 から再開）
 #### セルフレビュー手順（全モード共通）
 
 メインエージェントが PR diff を issue 要件と照合してレビューする（task/Li+issues.md#PR_Review_Judgment 参照）。
-- セルフレビュー pass → モード別の人間ゲートへ（下記）。
+- セルフレビュー pass → formal review record 投稿（下記）→ モード別の人間ゲートへ。
 - セルフレビュー fail → 修正してリコミット（CI ループ再開）。
+
+#### セルフレビューの formal record 投稿（全モード、必須）
+
+内部のセルフレビューが pass した後、AI は結果を GitHub 上の正式な PR review として必ず投稿する：
+
+```
+gh pr review {pr} -R {owner}/{repo} --comment --body "<セルフレビュー結果の要約>"
+```
+
+目的は PR の Reviews タブに audit trail を残し、AI レビュー記録を PR 作者属性から分離すること。
+実装メカニズムの注記：GitHub は `--add-reviewer` による self-assignment を silent に拒否する。PR author が自己レビュー記録を残す唯一の手段は `gh pr review --comment`（2026-04-20 に PR #1095 で empirical 検証済）。
+body には以下を含める：受け入れ条件の照合結果、scope deviation（ある場合）、次ステップ想定（例：trigger / semi_auto の minor-major では「人間レビュー待ち」）。
 
 #### モード別の人間ゲート（セルフレビュー pass 後）
 

--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -213,8 +213,8 @@ single parent PR flow 下では、親 issue も sub-issue と同じく `Closes #
 GitHub の自動クローズキーワード（公式リスト）：`close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved`。`Refs` はクローズキーワードではなく自動クローズしない。マージ時にクローズさせたい issue には `Refs` を使わない。
 
 PR 作成後：
-1. execution_mode == trigger かつリポジトリが auto-merge を許可している場合、auto-merge を有効化する：`gh pr merge {pr} -R {owner}/{repo} --auto --squash`
-2. CI ループへ即座に移行する。人間の指示は不要。
+1. CI ループへ即座に移行する。人間の指示は不要。
+2. マージの実行者は全モードで AI に統一されている（「マージ」節参照）。GitHub の auto-merge 機能には委譲しない。
 
 ### CI ループ
 
@@ -251,14 +251,27 @@ CI FAIL → 修正してリコミット（CI ループを step 1 から再開）
 
 ### PR レビュー
 
+**AI セルフレビューは全モード（trigger / semi_auto / auto）で必ず実行する。** マージ前のセルフレビュー省略は仕様違反である。セルフレビューが先に走り、必要に応じて人間レビューがその上に重ねられる（置き換えではない）。
+
 レビューの基準は repository state first である。issue 本文、リンク済みブランチの差分、PR 本文、CI 結果を読む。ローカルで動いたことだけではレビュー完了にしない。
 
-execution_mode == auto の場合（セルフレビュー）：
-- メインエージェントが PR diff を issue 要件と照合してレビューする（task/Li+issues.md#PR_Review_Judgment 参照）。
-- pass → マージへ移行。
-- fail → 修正してリコミット（CI ループ再開）。
+#### セルフレビュー手順（全モード共通）
 
-execution_mode == trigger の場合（外部レビュー）：
+メインエージェントが PR diff を issue 要件と照合してレビューする（task/Li+issues.md#PR_Review_Judgment 参照）。
+- セルフレビュー pass → モード別の人間ゲートへ（下記）。
+- セルフレビュー fail → 修正してリコミット（CI ループ再開）。
+
+#### モード別の人間ゲート（セルフレビュー pass 後）
+
+**execution_mode == auto**：人間ゲートなし。セルフレビュー pass → マージへ移行。
+
+**execution_mode == semi_auto**：タイプ連動の人間ゲート。
+- `patch` → 人間ゲートなし。セルフレビュー pass → マージへ移行。
+- `minor` / `major` → セルフレビュー pass 後に人間確認が必要（手順は trigger モードと同じ）。
+
+バージョン種別の判断軸はリリース時と同じ（「バージョン種別」節参照）。AI は PR 作成時点でタイプを提案し、判断が曖昧な場合は安全側（`minor`）に寄せて人間に確認する。
+
+**execution_mode == trigger**：全 PR で人間確認が必要。セルフレビュー pass 後に以下を実施する。
 
 webhook 経由を優先する。
 
@@ -279,6 +292,8 @@ gh pr view {pr} -R {owner}/{repo} --json reviewDecision --jq '.reviewDecision'
 
 ### マージ
 
+**マージの実行者は全モード（trigger / semi_auto / auto）で AI に統一されている。** すべての前提条件（セルフレビュー、モード別の人間ゲート、マージ可能状態チェック）が揃った時点で、AI が `gh pr merge` を実行する。GitHub の auto-merge 機能への委譲は廃止した。
+
 #### マージ前のマージ可能状態確認
 
 ```
@@ -290,23 +305,15 @@ gh pr view {pr} -R {owner}/{repo} --json mergeStateStatus --jq '.mergeStateStatu
 - `CONFLICTING` → rebase を試行。成功なら再 push + CI 再実行。失敗なら `git rebase --abort` → issue コメント → 人間にエスカレーション。
 - `BLOCKED` / `UNKNOWN` → 待機して再確認（GitHub が計算中の可能性）。
 
-execution_mode == trigger かつ PR 作成時に auto-merge が有効化されている場合、レビュー承認後に GitHub が自動的にスカッシュマージとブランチ削除を処理する。
+#### マージ戦略（全モード共通）
 
-#### auto モードのマージフロー
-
-既定のマージ戦略は `squash`（リポジトリの慣例に従う）。AI が squash 以外を選ぶ必要があると判断した場合のみ人間に確認する（pause して確認）。
+既定のマージ戦略は `squash`（リポジトリの慣例に従う）。
 
 ```
 gh pr merge {pr} -R {owner}/{repo} --squash
 ```
 
-#### trigger モードで auto-merge が利用不可の場合
-
-マージ戦略（squash / merge / rebase）を人間に確認してから実行する。
-
-```
-gh pr merge {pr} -R {owner}/{repo} --{strategy}
-```
+AI が `squash` 以外を選ぶ必要があると判断した場合のみ人間に確認する（pause して確認）。
 
 PR 本文に `Closes #xxx` が含まれていると、マージ時にプラットフォームが issue を自動クローズする（`Refs` はクローズキーワードではないため自動クローズしない）。
 
@@ -452,16 +459,36 @@ push が権限等で失敗した場合は人間にエスカレートする。省
 
 ### 実行モード
 
-`USER_REPOSITORY_EXECUTION_MODE` によって AI の自律度を切り替える。未設定の場合、セッション開始時に AI が対話で設定する。
+`USER_REPOSITORY_EXECUTION_MODE` によって AI の自律度を切り替える。未設定の場合、セッション開始時に AI が対話で設定する。有効値は `trigger` / `semi_auto` / `auto` の3種。デフォルトは `trigger`。
 
-| モード | 着手タイミング | PR レビュー |
-|--------|----------------|-------------|
-| `trigger`（デフォルト） | 人間が判断 | 人間がレビュー |
-| `auto` | AI が判断 | AI がレビュー |
+#### モードマトリクス
 
-両モード共通：issue 作成・クローズ・修正はアサイニー（AI）の責任。情報不足時は人間に確認する。リリースは常に人間の確認が必要。
+| 軸 | `trigger` | `semi_auto`（新設） | `auto` |
+|---|---|---|---|
+| 着手タイミング | 人間が判断 | AI が判断 | AI が判断 |
+| **AI セルフレビュー** | **必須** | **必須** | **必須** |
+| 人間による PR レビュー | 全 PR | `minor` / `major` のみ | なし |
+| マージ実行者 | **AI** | **AI** | **AI** |
+| リリース承認 | 人間 | 人間 | 人間 |
 
-trigger mode で実装開始の合図が出たら、ローカル専用の作業空間ではなく issue にリンクした個人ブランチを主作業面として使う。
+**AI セルフレビューは全モードで必ず実行する**（「PR レビュー」節参照）。
+**マージは全モードで AI が実行する**（「マージ」節参照）。GitHub の auto-merge 機能への委譲は廃止した。
+
+#### 各モードの運用
+
+- **`trigger` モード**：実装開始のタイミングを人間が決める。PR は AI のセルフレビューの上に、全 PR で人間レビューが必要。実装開始の合図が出たら、ローカル専用の作業空間ではなく issue にリンクした個人ブランチを主作業面として使う。
+- **`semi_auto` モード（新設）**：着手タイミングは AI が決める。PR レビューはタイプ連動。
+  - `patch` → セルフレビュー pass で AI が即マージ（人間レビューなし）
+  - `minor` / `major` → セルフレビュー pass 後に人間確認 → 承認で AI マージ
+  - 狙い：自己進化ループの回転が設計目標であり、低リスク変更（patch）の人間ボトルネックを外す。`minor` / `major` には人間の目を残す。
+  - 多層防御（意図的に2層）：Layer 1 = AI セルフレビュー + Li+ 仕様規律（日常的なミスを吸収）、Layer 2 = リリース時の人間ゲート（latest flip、致命的な user 露出を防止）。
+- **`auto` モード**：着手タイミングも PR レビューも AI が完結。人間レビューなし。
+
+#### 共通事項
+
+- issue 作成・クローズ・修正はアサイニー（AI）の責任
+- 情報不足時は人間に確認する
+- リリースは全モードで人間の確認が必要
 
 ---
 

--- a/operations/Li+github.md
+++ b/operations/Li+github.md
@@ -308,8 +308,15 @@ Event-Driven Operations
 
   Self-review procedure (all modes):
     Main agent reviews PR diff against issue requirements (see Li+issues.md#PR_Review_Judgment).
-    self-review pass -> proceed to mode-specific human gate (below).
+    self-review pass -> post formal review record (below) -> proceed to mode-specific human gate.
     self-review fail -> fix and recommit (restart [CI Loop]).
+
+  Self-review formal record (all modes, mandatory):
+    After internal self-review pass, AI MUST post the self-review outcome as a formal GitHub PR review:
+      gh pr review {pr} -R {owner}/{repo} --comment --body "<summary of self-review outcome>"
+    Rationale: creates audit trail visible on the PR's Reviews tab, separating AI's review record from PR author authorship.
+    Mechanism note: GitHub rejects `--add-reviewer` self-assignment silently; only `gh pr review --comment` works for PR author self-review records (empirically verified 2026-04-20 on PR #1095).
+    Review body must include: acceptance-criteria check result, scope deviations (if any), next-step expectation (e.g. "awaiting human review" for trigger / minor-major semi_auto).
 
   Mode-specific human gate after self-review:
 

--- a/operations/Li+github.md
+++ b/operations/Li+github.md
@@ -269,9 +269,8 @@ Event-Driven Operations
   Detail belongs in issue, not in PR.
 
   On PR created:
-  1 = if execution_mode == trigger and repository allows auto-merge:
-      gh pr merge {pr} -R {owner}/{repo} --auto --squash
-  2 = proceed to [CI Loop] immediately, no human instruction required.
+  1 = proceed to [CI Loop] immediately, no human instruction required.
+  Merge execution is unified to AI across all modes (see [Merge]). GitHub auto-merge handoff is no longer used.
 
   [CI Loop]
 
@@ -299,18 +298,32 @@ Event-Driven Operations
 
   [PR Review]
 
+  AI self-review is mandatory in every mode (trigger / semi_auto / auto).
+  Skipping self-review before merge is a spec violation. Self-review runs first; external human check (if any) is layered on top, not in place of it.
+
   Review basis:
     repository-state-first:
       review basis = issue body + linked branch + PR diff + CI result
       local-only success does not close review
 
+  Self-review procedure (all modes):
+    Main agent reviews PR diff against issue requirements (see Li+issues.md#PR_Review_Judgment).
+    self-review pass -> proceed to mode-specific human gate (below).
+    self-review fail -> fix and recommit (restart [CI Loop]).
+
+  Mode-specific human gate after self-review:
+
   if execution_mode == auto:
-    Self-review:
-      Main agent reviews PR diff against issue requirements (see Li+issues.md#PR_Review_Judgment).
-      pass -> proceed to [Merge].
-      fail -> fix and recommit (restart [CI Loop]).
+    No human gate. Self-review pass -> proceed to [Merge].
+
+  if execution_mode == semi_auto:
+    Type-gated human check.
+    patch -> no human gate. Self-review pass -> proceed to [Merge].
+    minor / major -> human check required after self-review pass (procedure = trigger mode's Review approval check below).
+    Version type is the same judgment axis used at release (see [Human Confirmation Required]#Release version rule). AI proposes type at PR creation time; on unclear, default to the safer side (minor) and ask human.
 
   if execution_mode == trigger:
+    Human check required on every PR after self-review pass.
     Review approval check:
       Prefer webhook over polling.
       if mcp__github-webhook-mcp available:
@@ -325,6 +338,9 @@ Event-Driven Operations
 
   [Merge]
 
+  Merge executor is AI in every mode (trigger / semi_auto / auto).
+  AI runs `gh pr merge` after all preconditions pass (self-review + mode-specific human gate, and mergeable state check). GitHub auto-merge handoff is no longer used.
+
   Pre-merge mergeable state check:
     gh pr view {pr} -R {owner}/{repo} --json mergeStateStatus --jq '.mergeStateStatus'
     CLEAN -> proceed to merge.
@@ -334,17 +350,10 @@ Event-Driven Operations
       if rebase fails: git rebase --abort -> comment on issue -> escalate to human
     BLOCKED or UNKNOWN -> wait and recheck (GitHub may still be computing)
 
-  if execution_mode == trigger and auto-merge was enabled at PR creation:
-    GitHub merges automatically on approval.
-
-  if execution_mode == auto:
-    Default merge strategy = squash (repo convention).
-    1 = gh pr merge {pr} -R {owner}/{repo} --squash
-    Confirm with human only when AI judges a deviation from squash is necessary (pause and ask).
-
-  if execution_mode == trigger and auto-merge unavailable:
-  1 = confirm merge strategy with human (squash / merge / rebase)
-  2 = gh pr merge {pr} -R {owner}/{repo} --{strategy}
+  Merge strategy:
+    Default = squash (repo convention).
+    All modes = AI runs: gh pr merge {pr} -R {owner}/{repo} --squash
+    Deviation from squash = AI pauses and asks human.
 
   Parent close condition: closed automatically on merge via issue reference.
 
@@ -451,15 +460,29 @@ Event-Driven Operations
   [Execution Mode]
 
   Mode source = USER_REPOSITORY_EXECUTION_MODE from Li+config.md
-  Valid values = trigger | auto
+  Valid values = trigger | semi_auto | auto
   Default = trigger
 
   If mode not set:
   Ask human at session start with options:
-    option A = "trigger: human decides when to start (timing only)"
-    option B = "auto: AI decides when to start"
+    option A = "trigger: human decides when to start; human reviews every PR"
+    option B = "semi_auto: AI decides when to start; AI self-reviews; human reviews minor/major only"
+    option C = "auto: AI decides when to start; AI self-reviews only"
   Write selection to Li+config.md.
   No manual editing required.
+
+  Mode matrix:
+
+  | axis                 | trigger          | semi_auto                    | auto        |
+  |----------------------|------------------|------------------------------|-------------|
+  | Execution timing     | human decides    | AI decides                   | AI decides  |
+  | AI self-review       | required         | required                     | required    |
+  | Human PR check       | every PR         | minor / major only           | none        |
+  | Merge executor       | AI               | AI                           | AI          |
+  | Release confirm      | human            | human                        | human       |
+
+  AI self-review is required in every mode. See [PR Review] for the self-review procedure and the type-gated human check in semi_auto.
+  Merge is executed by AI in every mode. See [Merge]. GitHub auto-merge handoff is no longer used.
 
   Common to all modes:
   Issue create/close/modify = assignee responsibility (AI in most cases).
@@ -471,11 +494,21 @@ Event-Driven Operations
   Issue create/update = allowed before execution trigger.
   Branch prepare/create = allowed before execution trigger.
   Implementation start = wait for human timing, then work from linked personal branch as primary surface.
-  PR review = human reviews.
+  PR review = AI self-review, then human check on every PR.
+
+  semi_auto mode:
+  Execution timing = AI decides.
+  PR review = AI self-review on every PR; human check layered on top for minor / major only.
+    patch = AI self-review pass -> AI merges (no human review).
+    minor / major = AI self-review pass -> human check required -> AI merges on approval.
+  Rationale: self-evolution loop rotation is the design goal; patch-level auto-merge removes the human bottleneck for low-risk changes while minor/major retain human oversight.
+  Defense-in-depth (intentionally two layers):
+    Layer 1 = AI self-review + Li+ spec discipline (absorbs everyday mistakes).
+    Layer 2 = Release human gate (latest flip on real-device verification, prevents catastrophic user exposure).
 
   auto mode:
   Execution timing = AI decides.
-  PR review = AI reviews.
+  PR review = AI self-review only (no human check).
 
   Release always requires human confirmation regardless of mode.
 


### PR DESCRIPTION
Closes #1088

Execution Mode に `semi_auto` を新設し、trigger と auto の中間点として patch は AI 自動マージ、minor / major はセルフレビュー後に人間確認を行うタイプ連動フローを導入した。AI セルフレビューは全モードで必須化し、マージ実行者も全モードで AI に統一（GitHub auto-merge 機能への委譲は撤廃）。

CODEOWNERS を撤去し、structural unlock を #1087 のリリース state gate に一本化する2層 defense (Layer 1 = AI セルフレビュー + Li+ 仕様規律、Layer 2 = リリース時の human gate) とした。`Li+config.md` テンプレートと `docs/4.-Operations.md` も同 PR 内で同期済み。branch protection の `require pull request reviews` 撤廃は PAT scope 不足で本 PR では未実施、人間側で調整が必要。