### PR TITLE
docs(home): add decision log nav section to Home.md

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -36,3 +36,15 @@ Li+ v1.0.0 の成立条件は到達済みとみなし、現在の本番はその
 | [B. Configuration](B.-Configuration) | 設定リファレンス |
 | [C. Bootstrap](C.-Bootstrap) | セッション起動フロー |
 | [D. Installation](D.-Installation) | Quickstartセットアップ手順 |
+
+---
+
+## 判断記録（a–z）
+
+セッションをまたぐ判断知を蓄積する decision log。設計上の分岐で選んだ理由、検証で確定した前提、外部システム依存などを小文字プレフィックス付きで記録する。
+
+| ページ | 内容 |
+|--------|------|
+| [a. Decision Log](a.-Decision-Log) | 判断記録レイヤーの運用ルール |
+| [b. Spec vs Implementation Order](b.-spec-vs-implementation-order) | 外部システム依存の spec 記述ルール |
+| [c. semi_auto Release Rule Dogfood](c.-semi-auto-release-rule-dogfood) | 2026-04-20 release rule + semi_auto dogfood の知見 |


### PR DESCRIPTION
Closes #1098

`docs/Home.md` の nav に判断記録 (`a.-` / `b.-` / `c.-`) のセクションを追加。本 PR は **semi_auto unlock 検証用の test PR** を兼ねる: Master が GitHub UI で「Review required なし / CODEOWNERS 警告なし / AI (bot) が merge 可能」の状態を literal 確認する目的。

**AI 側 merge は試行しない。** Master の UI 目視確認 + 指示を待つ。