### PR TITLE
spec(pr-creation): self-assign AI bot to PR assignees (operations, docs)

### DIFF
--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -213,8 +213,18 @@ single parent PR flow 下では、親 issue も sub-issue と同じく `Closes #
 GitHub の自動クローズキーワード（公式リスト）：`close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved`。`Refs` はクローズキーワードではなく自動クローズしない。マージ時にクローズさせたい issue には `Refs` を使わない。
 
 PR 作成後：
-1. CI ループへ即座に移行する。人間の指示は不要。
-2. マージの実行者は全モードで AI に統一されている（「マージ」節参照）。GitHub の auto-merge 機能には委譲しない。
+1. AI bot を PR の assignee に self-assign する：
+
+   ```
+   gh pr edit {pr} -R {owner}/{repo} --add-assignee liplus-lin-lay
+   ```
+
+   目的：issue 側の assignee は PR エンティティに自動継承されないため、PR の Assignees フィールドに AI bot を明示し「この PR は AI が owner」という UI 上の trail を残す。
+   メカニズム注記：GitHub は `--add-reviewer` の自己指定を silent に拒否するが、`--add-assignee` による PR author 自身の assignee 追加は許可される（2026-04-20 に PR #1099 で empirical 検証済）。
+   スコープ：assignee self-assign は UI trail のためであり、正式な self-review 記録（`gh pr review --comment`、「PR レビュー」節参照）を置き換えるものではない。
+
+2. CI ループへ即座に移行する。人間の指示は不要。
+3. マージの実行者は全モードで AI に統一されている（「マージ」節参照）。GitHub の auto-merge 機能には委譲しない。
 
 ### CI ループ
 

--- a/operations/Li+github.md
+++ b/operations/Li+github.md
@@ -269,7 +269,12 @@ Event-Driven Operations
   Detail belongs in issue, not in PR.
 
   On PR created:
-  1 = proceed to [CI Loop] immediately, no human instruction required.
+  1 = self-assign AI bot to PR assignees:
+      gh pr edit {pr} -R {owner}/{repo} --add-assignee liplus-lin-lay
+      rationale: existing issue-side assignee does not auto-propagate to the PR entity. Self-assign makes "AI owns this PR" explicit in the Assignees field.
+      mechanism note: GitHub rejects `--add-reviewer` self-assignment silently, but allows `--add-assignee` self-assign for PR author (empirically verified 2026-04-20 on PR #1099).
+      scope: assignee self-assign is UI trail only; it does not replace the formal self-review record (`gh pr review --comment`, see [PR Review]).
+  2 = proceed to [CI Loop] immediately, no human instruction required.
   Merge execution is unified to AI across all modes (see [Merge]). GitHub auto-merge handoff is no longer used.
 
   [CI Loop]


### PR DESCRIPTION
Closes #1100

[PR Creation] flow に AI bot を PR assignee に self-assign する手順を追加した (`operations/Li+github.md`)。issue 側 assignee は PR エンティティに自動継承されないため、`gh pr edit --add-assignee liplus-lin-lay` で PR Assignees フィールドに AI bot を明示し、「AI がこの PR の owner」という UI trail を残す。

`docs/4.-Operations.md` を日本語ナラティブで同期更新。既存の issue 側 assignee 手順・`gh pr review --comment` による formal self-review record 手順は不変。この PR 自身がこの spec の初回 dogfood (作成 flow 内で `--add-assignee` を自身に適用済み)。