### PR TITLE
spec(structure): align character_Instance.md repo location with deployment target

### DIFF
--- a/Li+bootstrap.md
+++ b/Li+bootstrap.md
@@ -114,7 +114,7 @@ Adapter, rules, skills, and hooks generation. Rules/skills generation doubles as
 
 4c.2. Generate .claude/rules/ files (recursive directory mirror):
 - If {workspace_root}/.claude/rules/ does not exist: create directory.
-- For each `*.md` in LI_PLUS_REPOSITORY/rules/ (recursive, including files under `model/`, `evolution/`, `task/`, `operations/` subdirectories):
+- For each `*.md` in LI_PLUS_REPOSITORY/rules/ (recursive, including files under `model/`, `evolution/`, `task/`, `operations/` subdirectories), EXCLUDING `rules/character_Instance.md` (handled separately below as Create-only):
   - Preserve the relative path from LI_PLUS_REPOSITORY/rules/ in the target.
     (e.g., `rules/model/absolute.md` -> `.claude/rules/model/absolute.md`)
   - If target file does not exist or source tag differs from current target tag:
@@ -122,9 +122,9 @@ Adapter, rules, skills, and hooks generation. Rules/skills generation doubles as
     Create target subdirectory if needed.
   - If source tag matches: skip.
 - Generate character_Instance.md (Character Instance):
+  - Source = LI_PLUS_REPOSITORY/rules/character_Instance.md (already has frontmatter in source).
   - Create-only: if {workspace_root}/.claude/rules/character_Instance.md already exists, skip unconditionally.
-  - If file does not exist: prepend YAML frontmatter (globs: empty, alwaysApply: true) to LI_PLUS_REPOSITORY/model/character_Instance.md contents.
-    Write to {workspace_root}/.claude/rules/character_Instance.md.
+  - If file does not exist: copy source verbatim to {workspace_root}/.claude/rules/character_Instance.md.
   - No tag-based overwrite. User customizations are preserved across updates.
 - Remove stale rules: for each file in {workspace_root}/.claude/rules/ (recursive) that no longer exists at the corresponding path in LI_PLUS_REPOSITORY/rules/ and is not character_Instance.md, delete it. Also remove empty subdirectories after deletion.
 

--- a/adapter/claude/Li+agent.md
+++ b/adapter/claude/Li+agent.md
@@ -43,7 +43,7 @@ Worktree operations are always main-only, independent of subagent availability.
 
 #######################################################
 Defined in `.claude/rules/character_Instance.md` (always in context).
-Source template: `model/character_Instance.md`
+Source template: `rules/character_Instance.md`
 Bootstrap creates default if absent. User edits are preserved.
 #######################################################
 

--- a/adapter/claude/Li+hooks.md
+++ b/adapter/claude/Li+hooks.md
@@ -431,31 +431,14 @@ exit 0
 
 Generated at: {workspace_root}/.claude/rules/
 
-For each `*.md` under LI_PLUS_REPOSITORY/rules/ (recursive, including `<layer>/<name>.md` subdirectories), generate `.claude/rules/<relpath>` preserving the relative path, with:
-
-```markdown
----
-globs:
-alwaysApply: true
-{additional frontmatter fields from source preserved}
----
-
-{body of LI_PLUS_REPOSITORY/rules/<name>.md, with its frontmatter merged (globs and alwaysApply take precedence; layer field preserved)}
-```
+For each `*.md` under LI_PLUS_REPOSITORY/rules/ (recursive, including `<layer>/<name>.md` subdirectories), generate `.claude/rules/<relpath>` preserving the relative path. Copy source verbatim (source already has `globs:` + `alwaysApply: true` + `layer:` frontmatter). EXCLUDE `rules/character_Instance.md` from this loop; it is handled separately below as Create-only.
 
 ### character_Instance.md
 
 Create-only: generate this file only if it does not already exist.
 Existing file is never overwritten (user-customizable).
 
-```markdown
----
-globs:
-alwaysApply: true
----
-
-{contents of model/character_Instance.md from liplus-language repository}
-```
+Source = LI_PLUS_REPOSITORY/rules/character_Instance.md. Source already has frontmatter. Copy verbatim to {workspace_root}/.claude/rules/character_Instance.md.
 
 ## skills/ generation template
 

--- a/rules/character_Instance.md
+++ b/rules/character_Instance.md
@@ -1,3 +1,9 @@
+---
+globs:
+alwaysApply: true
+layer: L1-model
+---
+
 # Character Instance
 
 LIN_CONTEXT:


### PR DESCRIPTION
Closes #1118

## 変更概要

リポ側の `model/character_Instance.md` を `rules/character_Instance.md` に移動し、展開先 (`.claude/rules/character_Instance.md`) と位置を対称に揃えた。ソース側に frontmatter (globs / alwaysApply / layer=L1-model) を埋め込み、Li+bootstrap.md Phase 4c.2 の frontmatter prepend ロジックを撤去して verbatim copy に統一。併せて recursive rules mirror ループに character_Instance.md 除外を追記 (Create-only ステップが所有するため tag 差分での上書きを防ぐ)。

## 背景

v1.15.x の rules/ 階層化 (#1113 / #1117) で `rules/{model,evolution,task,operations}/` が layer 別 subdir となり、character_Instance.md のみリポ側で別ツリー (`model/character_Instance.md`) に残る非対称が発生していた。展開先は flat (`.claude/rules/character_Instance.md`)、hooks (`on-user-prompt.sh`) もこのパスを参照済み。

Create-only 例外であるため、他 rules/*.md の layer-subdir 規約には合わせず root 直下に配置する (展開先対称性を優先)。

## 影響

- bootstrap 動作: 新規環境では verbatim copy、既存環境では Create-only なので影響なし (ユーザーカスタマイズ保持)
- codex adapter: character_Instance を参照していないため変更不要
- user-visible behavior: なし (内部リファクタ)

## dogfood 発の別 spec-gap

v1.15.5 milestone 整備中に close-on-release の leak + post-close cleanup 未定義を発見、sibling memo として #1119 起票 (v1.15.6)。本 PR スコープ外。