### PR TITLE
docs: stale links + Home.md sync + Opus 4.7 + RAG limitation rewrite [patch]

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Li+ addresses **what should be satisfied** — and governs how an AI prioritizes
 2. Place it in your workspace root and edit the settings
 3. Start a session and tell the AI: "Execute the workspace Li+config.md" (first time requires security approval)
 
-See the [Installation Guide](https://github.com/Liplus-Project/liplus-language/wiki/C.-Installation) for details.
+See the [Installation Guide](https://github.com/Liplus-Project/liplus-language/wiki/D.-Installation) for details.
 
 ---
 
@@ -101,9 +101,8 @@ What's *not* exchangeable: the principle that correctness is observable behavior
 
 ### Current limitations
 
-- No GitHub RAG yet — the AI must actively fetch issue state instead of having it as ambient context, making autonomous issue lifecycle management expensive
-- The "create freely, close freely" issue workflow depends on low-cost access to the full issue landscape
 - Some workflow transitions still benefit from a human nudge, even where rules permit full autonomy
+- L5 Notifications layer is a reserved slot for future channel-based webhook delivery; current implementation relies on hooks and CI polling as an interim workaround (the primary channel feature is CLI-only at this stage and does not yet cover all host environments)
 
 ---
 
@@ -111,7 +110,8 @@ What's *not* exchangeable: the principle that correctness is observable behavior
 
 | Environment | Status | Notes |
 |-------------|--------|-------|
-| Claude Code (Opus 4.6) | **Recommended** | Full capability with hooks and subagent delegation |
+| Claude Code (Opus 4.7, 1M context) | **Recommended** | Full capability with hooks and subagent delegation |
+| Claude Code (Opus 4.6) | Good | Previous recommended tier |
 | Claude Code (Sonnet 4.6) | Good | Strong for development work |
 | Claude Sonnet 4.6 (claude.ai) | Fair | Strong for documents, not ideal for continuous work |
 | Codex (GPT 5.4) | Good | Practical, tends to over-weight structure |
@@ -136,7 +136,8 @@ Minimum: roughly Claude Sonnet 4.6 equivalent or above.
 | [6. Adapter](https://github.com/Liplus-Project/liplus-language/wiki/6.-Adapter) | Adapter layer specification |
 | [A. Concept](https://github.com/Liplus-Project/liplus-language/wiki/A.-Concept) | Design philosophy |
 | [B. Configuration](https://github.com/Liplus-Project/liplus-language/wiki/B.-Configuration) | Configuration reference |
-| [C. Installation](https://github.com/Liplus-Project/liplus-language/wiki/C.-Installation) | Quickstart setup |
+| [C. Bootstrap](https://github.com/Liplus-Project/liplus-language/wiki/C.-Bootstrap) | Session startup flow |
+| [D. Installation](https://github.com/Liplus-Project/liplus-language/wiki/D.-Installation) | Quickstart setup |
 
 ---
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -11,7 +11,7 @@ Li+ v1.0.0 の成立条件は到達済みとみなし、現在の本番はその
 
 ---
 
-## 要求仕様書（1–9）
+## 要求仕様書（1–6）
 
 各レイヤーの要求と仕様を一体として定義する。
 
@@ -26,7 +26,7 @@ Li+ v1.0.0 の成立条件は到達済みとみなし、現在の本番はその
 
 ---
 
-## 参考文書（A–Z）
+## 参考文書（A–D）
 
 構想・設定・導入手順などの参照資料。
 
@@ -39,7 +39,7 @@ Li+ v1.0.0 の成立条件は到達済みとみなし、現在の本番はその
 
 ---
 
-## 判断記録（a–z）
+## 判断記録（a–d）
 
 セッションをまたぐ判断知を蓄積する decision log。設計上の分岐で選んだ理由、検証で確定した前提、外部システム依存などを小文字プレフィックス付きで記録する。
 
@@ -48,3 +48,4 @@ Li+ v1.0.0 の成立条件は到達済みとみなし、現在の本番はその
 | [a. Decision Log](a.-Decision-Log) | 判断記録レイヤーの運用ルール |
 | [b. Spec vs Implementation Order](b.-spec-vs-implementation-order) | 外部システム依存の spec 記述ルール |
 | [c. semi_auto Release Rule Dogfood](c.-semi-auto-release-rule-dogfood) | 2026-04-20 release rule + semi_auto dogfood の知見 |
+| [d. Layer Reorg Rationale](d.-layer-reorg-rationale) | L1–L6 層再編の設計意図と L5/L6 位置付け |


### PR DESCRIPTION
## 概要

v1.16.0 までの構造変更（L1-L6 再編、GitHub RAG MCP 統合、Opus 4.7 対応、`docs/d.-layer-reorg-rationale.md` 追加）に対して README と Home.md が追従できていなかった箇所を Phase A patch として掃除する。

構造再設計（A-D の onramp 順、`_Sidebar.md` 新設、Notifications L5 の位置付け明記等）は Phase B #1140 で別扱い。

## 変更点

### README.md
- L30 Installation Guide リンク: `wiki/C.-Installation` → `wiki/D.-Installation` (リンク切れ修正)
- L139 Documentation テーブル: `C. Installation` 行を `C. Bootstrap` + `D. Installation` の 2 行に分割
- Compatibility テーブル: Opus 4.7 (1M context) を Recommended に置換、Opus 4.6 は旧推奨として残す
- Current limitations: 「No GitHub RAG yet」行を削除 (`mcp__GitHub_RAG_MCP__*` 統合済み)、L5 Notifications placeholder 状態を追記

### docs/Home.md
- 判断記録テーブルに `d.-layer-reorg-rationale` 行を追加
- 見出しスコープを実体に合わせて修正:
  - `要求仕様書（1–9）` → `要求仕様書（1–6）`
  - `参考文書（A–Z）` → `参考文書（A–D）`
  - `判断記録（a–z）` → `判断記録（a–d）`

## mode

semi_auto / patch (docs 修正のみ、user/system 観測可能な挙動変更なし)。AI セルフレビュー後に直接 merge。

Closes #1139
Refs #1140