### PR TITLE
docs(5-notifications): explicit L5 placeholder status [patch]

### DIFF
--- a/docs/5.-Notifications.md
+++ b/docs/5.-Notifications.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 現状（プレースホルダ状態）
+
+L5 Notifications Layer は webhook-mcp の channel 配信機能 GA 待ちの予約スロットである。`rules/notifications/` ディレクトリは意図的に不在であり、書き忘れではない。realtime trigger（push 受信時に特定 rule を強制再読込する等の挙動）の実装方式が確定するまで、rules/ 搭載判断は保留している。
+
+現状の暫定運用は、hooks による強制読み込みと CI polling の組み合わせで実現している。一方で意味論（`inspect` / `claim` / `ack` / `consume` / `mention` / `cleanup`）の定義自体は本文書で確定済みであり、transport が receptive 受信へ切り替わっても上位意味論は変わらない。詳細な判断経緯は [判断記録 d.-layer-reorg-rationale](d.-layer-reorg-rationale) を参照。
+
+---
+
 ## 目的
 
 Li+ は前景セッションで軽量な通知差分を扱うが、共有 queue を雑に排水すると別 AI や別セッションの作業面を壊す。通知レイヤーは、通知の確認、所有、既読化、完了、会話への言及、清掃を分離し、前景スレッドの安定性を守る。
@@ -129,7 +137,7 @@ transport は polling でも push でもよい。前景一致判定、例外的 
 
 **L4 Operations Layer:** CI / review / release 待機で必要なイベント種別を定義するが、共有 queue の ownership と cleanup 規則は通知レイヤーを再定義しない。
 
-**L6 Adapter Layer:** 各ターン先頭で transport を `inspect` し、前景へ渡す summary を整える。関連性判断と destructive consume の正本は通知レイヤーに従う。
+**L6 Adapter Layer:** 各ターン先頭で transport を `inspect` し、前景へ渡す summary を整える。関連性判断と destructive consume の正本は通知レイヤーに従う。L5 の realtime trigger が確定するまでの暫定期間、L6 Adapter は transport binding の実装責務（`on-user-prompt.sh` 経由の webhook polling 等）を抱え込む。これはアダプターの過渡的な膨らみであり、L5 側で realtime trigger が確定した段階で L6 から L5 へ移譲される。
 
 ---
 


### PR DESCRIPTION
## 変更要約

`docs/5.-Notifications.md` に L5 Notifications Layer のプレースホルダ状態を明記するセクションを追加した。あわせて「他レイヤーとの接続」の L6 Adapter 項目に暫定 transport binding 責務を追記。

## 変更内容

- intro 直後、`## 目的` の前に `## 現状（プレースホルダ状態）` セクションを新設。
  - L5 は webhook-mcp の channel 配信機能 GA 待ちの予約スロットであり、`rules/notifications/` 不在は意図的（書き忘れではない）であることを明記。
  - 現状の暫定運用（hooks 強制読み込み + CI polling）を記述。
  - 意味論（`inspect` / `claim` / `ack` / `consume` / `mention` / `cleanup`）の定義自体は本文書で確定済みであることを明確化。
  - 判断経緯の詳細は `d.-layer-reorg-rationale` への相互参照で担保。
- `## 他レイヤーとの接続` の **L6 Adapter Layer** 項目に、realtime trigger 確定までの暫定 transport binding 責務（`on-user-prompt.sh` 経由の webhook polling 等）を抱えることを追記。

## 意図・背景

`docs/5.-Notifications.md` 単独では L5 の実装状態（rules/ 不在の理由、暫定運用、GA 待ち予約スロットであること）が customizer から見えず、判断根拠を辿るには `docs/d.-layer-reorg-rationale.md` を別途読む必要があった。customizer が docs/5 を直接読んだ時点で L5 の現状を把握できるようにするための可読性補強。

## 制約遵守

- 既存セクション・意味論定義は無変更（保持）。
- `rules/*.md` / `skills/*/SKILL.md` は未変更。
- `d.-layer-reorg-rationale.md` は相互参照のみ（変更なし）。
- docs = source = test 原則を維持。

Closes #1143
Refs #1140