### PR TITLE
docs(C-bootstrap): align Step with Li+bootstrap Phase 1-6 [patch]

### DIFF
--- a/docs/C.-Bootstrap.md
+++ b/docs/C.-Bootstrap.md
@@ -1,176 +1,220 @@
 # ブートストラップ仕様書
 
-本文書は Li+ のセッション起動フロー（Li+bootstrap.md）の仕様を定義する。
-Li+config.md の設定値を前提とし、セッション開始時に AI が自動実行するステップを記述する。
+本文書は Li+ のセッション起動フロー（`Li+bootstrap.md`）の仕様を定義する。
+Li+config.md の設定値を前提とし、セッション開始時に AI が自動実行する Phase を記述する。
 
 ---
 
 ## 概要
 
-セッション起動フローは **Li+bootstrap.md** に定義されている。Li+config.md はユーザー設定のみを保持し、起動ロジックは分離されている。
+セッション起動フローは **`Li+bootstrap.md`** に定義されている。Li+config.md はユーザー設定のみを保持し、起動ロジックは分離されている。
 
-AI は Li+config.md を読み込んだ後、Li+bootstrap.md のステップに従って環境検出・認証・バージョン取得・設定ファイル生成を実行する。
+AI は Li+config.md を読み込んだ後、`Li+bootstrap.md` の Phase 1 から Phase 6 を順に実行する。各 Phase は直前までの Phase を依存前提として宣言する。認証情報をチャットに出力してはいけない。
 
 ---
 
-## ステップ1: 環境検出
+## Phase 1: 環境検出
 
-ランタイム環境を自動判定する。
+参照: `Li+bootstrap.md` Phase 1。依存なし。
+
+**1.1. ランタイム環境の自動判定**
 
 | 環境変数 | 判定結果 |
 |---------|---------|
-| `CODEX_HOME` or `CODEX_THREAD_ID` が存在 | runtime=codex |
+| `CODEX_HOME` または `CODEX_THREAD_ID` が存在 | runtime=codex |
 | `CLAUDECODE` が存在 | runtime=claude |
-| どちらもなし | ユーザーに1回確認 |
+| どちらもなし | ユーザーに1回確認し、回答で続行 |
 
----
-
-## ステップ2: Li+config.md のパーミッション保護
+**1.2. Li+config.md のパーミッション保護**
 
 Li+config.md にはトークンが含まれるため、ファイルパーミッションを制限する。
 
-- Linux/Mac: `chmod 600 Li+config.md`（ownerのみ read/write）
+- Linux/Mac: `chmod 600 Li+config.md`（owner のみ read/write）
 - 既に 600 以下の場合はスキップ
 - Windows: スキップ（ユーザープロファイル配下では NTFS ACL が既に制限済み）
 
 ---
 
-## ステップ3: workspace言語契約の解決
+## Phase 2: 認証と設定
 
-`LI_PLUS_BASE_LANGUAGE` と `LI_PLUS_PROJECT_LANGUAGE` を解決する。
+参照: `Li+bootstrap.md` Phase 2。依存: Phase 1（ランタイム検出済み）。
 
-- これらは**配布先workspace専用**の設定であり、liplus-language リポジトリ内部の日本語運用とは分離する
-- `LI_PLUS_BASE_LANGUAGE` は人間との対話の既定言語。issue/discussion/PRコメントのような会話返信もこちらが既定
-- `LI_PLUS_PROJECT_LANGUAGE` は issue / PR / commit body や保存する要求仕様書など durable artifact の既定言語
-- どちらか未設定の場合、AIがセッション開始時に対話で確認し、Li+config.mdへ書き戻す
-- 推奨初期値は `基本言語 = 現在の対話言語`、`プロジェクト言語 = 基本言語と同じ`
-- 人間が「bodyは英語で」のように成果物言語を明示した場合、その指示を優先できる
-
----
-
-## ステップ4: gh CLIインストール
+**2.1. gh CLI のインストール**
 
 `~/.local/bin/gh` が存在しない場合のみインストールする。
 
-- sudo不要、PATH変更不要
+- sudo 不要、PATH 変更不要
+- 以降の gh 操作は常にフルパス `~/.local/bin/gh` を使用（Bash ツールは PATH を永続化しないため）
 - `/tmp` は使用禁止（他セッションとの権限衝突のため）
-- インストール先: `~/.local/bin/gh`（以降の全操作でフルパスを使用）
+- 手順: `mkdir -p ~/.local/bin` → `~/.local/bin/gh.tar.gz` に tarball を curl → その場で展開 → `~/.local/bin/gh` を配置 → tarball を削除
+
+**2.2. GH_TOKEN の読み込みと認証**
+
+`GH_TOKEN` を読み込んで gh CLI で認証する。認証情報はチャットに出力しない。認証後は keyring にトークンが保存されるため、以降の `gh` コマンドに `GH_TOKEN` の明示的な export は不要。
+
+**2.3. workspace 言語契約の解決**
+
+`LI_PLUS_BASE_LANGUAGE` と `LI_PLUS_PROJECT_LANGUAGE` を解決する。
+
+- これらは **配布先 workspace 専用** の設定であり、LI_PLUS_REPOSITORY 内部のガバナンスとは分離する
+- `LI_PLUS_BASE_LANGUAGE` は人間との対話の既定言語。issue/discussion/PR コメントのような会話返信もこちらが既定
+- `LI_PLUS_PROJECT_LANGUAGE` は issue / PR / commit body や保存する要求仕様書など durable artifact の既定言語
+- どちらか未設定の場合、AI がセッション開始時に1回対話で確認し、Li+config.md へ書き戻す
+- 推奨初期値は「基本言語 = 現在の対話言語」「プロジェクト言語 = 基本言語と同じ」
+- bootstrap の ask と Li+config.md への書き戻しは、セッション開始時の config 未解決パスにのみ適用する。config が解決済みなら、セッション途中の再 ask と config 再書き込みは本 Phase の対象外とする
+- runtime precedence（人間の明示指示 > スレッド合意 > config > 再 ask）はアダプターの Workspace_Language_Contract が担い、セッション全体を通して本 Phase を再起動せずに働く
+
+**2.4. Webhook 配信モードの解決（任意）**
+
+- `LI_PLUS_WEBHOOK_DELIVERY`（`channel` または `poll`）はアダプターが runtime で参照する
+- 未設定時の既定は `poll`。bootstrap 側の追加処理は不要
 
 ---
 
-## ステップ5: 認証
+## Phase 3: Li+ ソース解決
 
-`GH_TOKEN` を読み込んでgh CLIで認証する。認証情報はチャットに出力しない。認証後は keyring にトークンが保存されるため、以降の `gh` コマンドに `GH_TOKEN` の明示的な export は不要。
+参照: `Li+bootstrap.md` Phase 3。依存: Phase 2（gh CLI 認証済み）。
 
----
+**3.1. `LI_PLUS_CHANNEL` による対象バージョンの決定**
 
-## ステップ6: Li+ファイル取得と適用
+- `latest`: Latest release タグ（stable release のみ）
+- `release`: pre-release を含む最新リリースタグ（GitHub Release API）
+- `tag`: 作成日順で最新の git タグ（GitHub Release が未作成のタグも含む）。clone モードでは `git ls-remote --tags --sort=-creatordate {repo_url} | head -1` を使用
+- 包含関係は tag ⊇ release ⊇ latest。tag は GitHub Release 作成前の pre-release タグ検証を意図する。api モードの tag 拡張は現時点ではスコープ外
+- バージョン確認は起動のたびに Phase 4 へ進む前に必ず実施する。ローカル clone が古いままでも黙って継続してはいけない
 
-`LI_PLUS_CHANNEL` で対象バージョンを決定し、`LI_PLUS_MODE` に従ってLi+ファイルを取得・適用する。
+**3.2. `LI_PLUS_MODE` による Li+ ソース取得**
 
-必須取得: `rules/**/*.md`（L1–L4 の常時ロード分、subdir `model/` `evolution/` `task/` `operations/` 含む）
-条件付き: `skills/**/SKILL.md`（hookが無い環境では Codex adapter のトリガー表に従って手動読み込み）
+**api モード:**
+- `rules/` 配下の全 `*.md` を対象バージョンで GitHub API から LI_PLUS_REPOSITORY より取得
+- `skills/` 配下の全 `<name>/SKILL.md` を対象バージョンで GitHub API から取得
+- 検出した runtime に応じて `adapter/claude/` または `adapter/codex/` を取得
 
-起動時は、Li+ファイルを読む前に **毎回必ず対象バージョン確認** を行う。
-ローカル clone が古いままでも黙って継続してはいけない。
-
-**cloneモードの場合：**
+**clone モード:**
 
 1. 対象リポジトリは LI_PLUS_REPOSITORY の対象バージョン
-2. ワークスペース内に `liplus-language` ディレクトリが存在しない場合 → 対象タグを直接 clone
-3. 存在する場合：
-   - `fetch --tags` を実行
-   - 現在 checkout 中のタグと、`LI_PLUS_CHANNEL` から解決した対象タグを両方確認
-   - 一致する場合のみ、そのまま Li+ ファイルを読む
-   - 不一致の場合、**人間にどうするか確認する**
-   - この選択が解決するまで bootstrap 完了扱いにしない
-4. 人間確認の最小選択肢：
-   - 対象タグへ更新してから続行
-   - 今セッションは現在タグのまま続行
-5. 人間が更新に同意した場合のみ対象タグへ checkout
-6. 人間が現在タグのまま続行を選んだ場合は、現在タグと対象タグを明示してから続行
-7. `rules/**/*.md` を読み込む（L1–L4 の常時ロード分、subdir 含む常に必須）
-8. `skills/**/SKILL.md` はトリガー時に読み込む — hookが無い環境では Codex adapter のトリガー表に従って手動読み込み。hookが常時適用セクションをターンごとに注入する場合、起動時の skill 一括読み込みは不要
+2. ワークスペース内に LI_PLUS_REPOSITORY 由来のディレクトリが存在するか確認
+   - 存在しない → 対象タグを直接 clone し、手順 3 へ
+   - 存在する → `fetch --tags` を実行し:
+     a. 現在 checkout 中のタグと、`LI_PLUS_CHANNEL` から解決した対象タグを両方確認して報告
+     b. 一致する場合はそのまま続行
+     c. 不一致の場合、Phase 4 へ進む前に人間にどうするか確認する。この選択が解決するまで bootstrap 完了扱いにしない。最小選択肢は「対象タグへ更新してから続行」「今セッションは現在タグのまま続行」
+     d. 人間が更新に同意した場合のみ対象タグへ checkout
+     e. 現在タグのまま続行を選んだ場合は、現在タグと対象タグを明示してから続行
+3. 解決済みタグでソースファイルが参照可能な状態になる。読み込みは Phase 4 が担う
 
 ---
 
-## ステップ7: 設定ファイルの自動生成（Bootstrap）
+## Phase 4: ホスト統合
 
-adapter 配下のテンプレートから、ランタイムに応じた設定ファイルを生成する。source はターゲット側の生成先と同名に揃えてある（target-native 命名）。
+参照: `Li+bootstrap.md` Phase 4。依存: Phase 3（ソース解決済み、対象タグ確定済み）。
 
-| ランタイム | ソース | 生成先 |
-|-----------|--------|--------|
-| codex | `adapter/codex/AGENTS.md` | `{workspace_root}/AGENTS.md`（Li+config.md と同じディレクトリ） |
-| claude | `adapter/claude/CLAUDE.md` | `{workspace_root}/.claude/CLAUDE.md`（Li+config.md と同じディレクトリ直下） |
+ランタイム固有の統合処理。検出した runtime で分岐する。adapter / rules / skills / hooks を生成する。rules/skills の生成はレイヤーの読み込みを兼ねる（生成された `.claude/rules/` `.claude/skills/` をホストが毎ターン読むため明示 read は不要）。
 
-生成物には `{LI_PLUS_TAG}` プレースホルダがあり、bootstrap 時に解決済みターゲットタグへ置換する。
+生成物には `{LI_PLUS_TAG}` プレースホルダがあり、bootstrap 時に Phase 3 で解決済みターゲットタグへ置換する。
 
-判定ロジック：
+**共通判定ロジック**
 
 自動スキップ・自動置換は `Li+ BEGIN` sentinel 検出時にのみ適用する。sentinel 不在（legacy file）はユーザー判断を必須とする。legacy file を暗黙に上書きすると、ユーザー自身が書いた内容を同意なく破壊することになるため禁止する。
 
-- ファイルが存在しない → ソーステンプレートの内容で新規作成
-- ファイルが存在し `Li+ BEGIN` sentinel を含む：
-  - sentinel 内のタグと現在のターゲットタグを比較
-  - 一致 → スキップ（最新）
-  - 不一致またはタグなし → Li+ BEGIN 〜 Li+ END 間を差し替え（セクション外は保護）
-- ファイルが存在するが sentinel なし → ユーザーに確認（Li+セクションを追記 or スキップ）
+### Phase 4 claude: Claude Code 統合
 
-**runtime=claude の場合: rules/skills/hooks bootstrap**
+**4c.1. アダプターの bootstrap**
 
-rules/skills ファイルはリポジトリの `rules/` / `skills/` から直接生成し、hook ファイルは adapter/claude/hooks-settings.md（settings.json）と adapter/claude/hooks/*.sh（スクリプト本体）から生成する。
+- target = `{workspace_root}/.claude/CLAUDE.md`, source = `adapter/claude/CLAUDE.md`
+- ファイルが存在しない → ソースの内容で新規作成
+- ファイルが存在し `Li+ BEGIN` sentinel を含む:
+  - sentinel 内のタグ（例 `Li+ BEGIN (build-2026-03-30.14)` → `build-2026-03-30.14`）を抽出
+  - 現在のターゲットタグと一致 → スキップ（最新）
+  - 不一致またはタグなし → `Li+ BEGIN` 〜 `Li+ END` 間（両端含む）をソース内容で差し替え、セクション外は保護
+- ファイルが存在するが sentinel なし → ユーザーに確認（Li+ セクションを追記 or スキップ）
 
-**ステップ 7b: rules/ ファイル生成（再帰ディレクトリミラー）**
+**4c.2. `.claude/rules/` ファイル生成（再帰ディレクトリミラー）**
 
-- `.claude/rules/` ディレクトリが存在しなければ作成
-- リポジトリの `rules/**/*.md`（subdir `model/` `evolution/` `task/` `operations/` 含む）を1ファイルずつ、相対パスを保持したまま `.claude/rules/<relpath>` へミラー。frontmatter に `globs:`（空）と `alwaysApply: true` を含めるよう保証する。`layer` フィールドは保持する。L5 Notifications / L6 Adapter に対応する subdir が `rules/` 配下に存在しないのは設計意図であり欠落ではない（L5 は realtime trigger 実装確定までの予約席、L6 はテンプレート + hook 駆動でそもそも rules/ に載らない）。設計意図の詳細は [判断記録 d.-layer-reorg-rationale](d.-layer-reorg-rationale) を参照する
-- character_Instance.md は初回のみ生成し、既存ファイルは上書きしない（ユーザーカスタマイズ可能）
-- ソースタグと現在のターゲットタグを比較し、一致する場合はスキップ（最新）
-- `.claude/rules/` 内でリポジトリ側に存在しないファイル（character_Instance.md を除く）は削除。空の subdir も削除
+- `{workspace_root}/.claude/rules/` が存在しなければ作成
+- LI_PLUS_REPOSITORY の `rules/**/*.md` を再帰走査し（`model/` `evolution/` `task/` `operations/` subdir を含む）、`rules/character_Instance.md` を除いた各ファイルについて:
+  - LI_PLUS_REPOSITORY/rules/ からの相対パスを保持してターゲットへ配置する（例: `rules/model/absolute.md` → `.claude/rules/model/absolute.md`）
+  - ターゲットが存在しない、またはソースタグが現在のターゲットタグと異なる場合、ソース内容をコピー。ソースは既に `globs:` + `alwaysApply: true` + `layer:` frontmatter を含む
+  - 必要なら subdir を作成
+  - ソースタグが一致する場合はスキップ
+- `character_Instance.md` の生成:
+  - source = LI_PLUS_REPOSITORY/`rules/character_Instance.md`（frontmatter 済み）
+  - Create-only: `{workspace_root}/.claude/rules/character_Instance.md` が既に存在すれば無条件でスキップ
+  - 存在しない場合のみソースをそのままコピー
+  - タグベースの上書きは行わない。ユーザーカスタマイズはアップデートをまたいで保護される
+- 古い rules の削除: `{workspace_root}/.claude/rules/` 配下で LI_PLUS_REPOSITORY/rules/ の対応パスに存在しないファイル（`character_Instance.md` を除く）は削除。空になった subdir も削除
 
-**ステップ 7c: skills/ ファイル生成（再帰ディレクトリミラー）**
+**4c.3. `.claude/skills/` ファイル生成（flat ディレクトリミラー）**
 
-- `.claude/skills/` ディレクトリが存在しなければ作成
-- リポジトリの `skills/<layer>/<name>/SKILL.md` を1ファイルずつ、相対パスを保持したまま `.claude/skills/<layer>/<name>/SKILL.md` へ verbatim コピー（ソースが既に Claude Code skill frontmatter を含む）
-- ソースタグと現在のターゲットタグを比較し、一致する場合はスキップ（最新）
-- `.claude/skills/` 内でリポジトリ側に存在しない `<layer>/<name>/` ディレクトリは削除。空の layer subdir も削除
+- `{workspace_root}/.claude/skills/` が存在しなければ作成
+- LI_PLUS_REPOSITORY の `skills/<name>/SKILL.md` を **flat** に走査する（subdir は持たない）:
+  - target = `.claude/skills/<name>/SKILL.md`
+  - 必要なら subdir を作成
+  - ソースをそのままコピー（ソースは既に Claude Code skill frontmatter を含む）
+  - ソースタグが一致する場合はスキップ
+- 古い skills の削除: `.claude/skills/` 配下で LI_PLUS_REPOSITORY/skills/ に存在しない `<name>/` ディレクトリは再帰削除
 
-**hook bootstrap**
+注意: Claude Code の skill 探索は `.claude/skills/` 配下の subdir を辿らない。skill 名は flat 階層で一意である必要があり、レイヤー属性は skill 名の接頭辞規約で表現する（例: `evolution-judgment-learning`）。
 
-- settings.json が存在せず `UserPromptSubmit` を含まない → 全ファイル新規生成
-- settings.json が存在し `UserPromptSubmit` を含む：
-  - hook スクリプトのソースタグと現在のターゲットタグを比較
-  - 一致 → スキップ（最新）
-  - 不一致またはタグなし → hook スクリプトのみ再生成（settings.json は再生成しない）
-- .sh ファイルには実行権限を付与
-- on-session-start.sh は Cold-start Synthesis 用の素材を出力（`rules/evolution/cold-start-synthesis.md` のリテラル + 直近 docs/a.- 先頭 + 最新リリースタグ + open in-progress issue + self-evaluation 先頭）
-- on-user-prompt.sh は Character 再通知と Webhook 通知のみ（常時注入は rules/skills に移行）
-- post-tool-use.sh は `gh pr create` 後の sub-issue refs 自動追記のみを担う（旧 focus pointer 注入は不要、rules/* が常時ロードされ skills/* が description で auto-invocation するため）
+**4c.4. hooks の bootstrap**
 
-rules/ により L1–L4 の常時ロード分が常時コンテキストに存在し、skills/ により残りの責務が必要時に自動読込される。hook は補助的に残る。
+- ソースファイル:
+  - `adapter/claude/hooks-settings.md` — `settings.json` の JSON ブロックをリテラルで保持
+  - `adapter/claude/hooks/*.sh` — hook スクリプト本体（そのままコピーし、`{LI_PLUS_TAG}` プレースホルダを解決済みターゲットタグへ置換）
+- `{workspace_root}/.claude/settings.json` が存在しない:
+  - `adapter/claude/hooks-settings.md` の JSON コードブロックから settings.json を生成
+  - `{workspace_root}/.claude/hooks/` を作成し、`adapter/claude/hooks/*.sh` をすべてコピー
+  - SessionStart は startup / resume / clear / compact の 4 matcher を使用し、Cold-start Synthesis 素材がどのセッション入口でも出力されるようにする
+- `{workspace_root}/.claude/settings.json` が存在する:
+  - settings.json は変更しない。workspace が所有するファイルであり、Li+ はユーザー追加キー（permissions / env / theme / 他コンポーネント hook）を暗黙に書き換えない
+  - 既存の `{workspace_root}/.claude/hooks/*.sh` 内のソースタグを確認（例: `# Source: adapter/claude/hooks/on-session-start.sh (build-2026-03-30.14)`）
+  - 現在のターゲットタグと一致 → スキップ（最新）
+  - 不一致またはタグなし → `adapter/claude/hooks/*.sh` を再コピーし、`{LI_PLUS_TAG}` を現在のターゲットタグへ置換（settings.json は再生成しない）
+- `on-session-start.sh` が Cold-start Synthesis 素材の emitter。stdout はセッション開始コンテキストへ注入される（Claude Code SessionStart 契約）。素材は `rules/cold-start-synthesis.md` のリテラル、直近の `docs/a.-` 先頭、最新リリースタグ、open in-progress issue、self-evaluation 先頭。synthesis は hook ではなく Character_Instance を介して AI が行う
+- `.sh` ファイルには実行権限を付与
 
-Bootstrap は次回セッションから有効。現セッションは Li+config.md の実行で継続する。
+注意: bootstrap は次回セッションから有効。現セッションは Li+config.md の実行で継続する。
+
+### Phase 4 codex: Codex 統合
+
+Codex には rules/skills 機構がないため、レイヤーは明示 read で読み込む。
+
+**4x.1. アダプターの bootstrap**
+
+- target = `{workspace_root}/AGENTS.md`, source = `adapter/codex/AGENTS.md`
+- sentinel 判定ロジックは 4c.1 と同一（存在しなければ新規、sentinel ありタグ一致でスキップ、不一致で section 差し替え、sentinel なしでユーザー確認）
+
+**4x.2. Li+ レイヤーの直接読み込み**
+
+- LI_PLUS_REPOSITORY の `rules/*.md` をすべて読み込む（always-on）
+- `skills/<name>/SKILL.md` は `adapter/codex/AGENTS.md` のトリガー表に従いオンデマンドで読み込む
 
 ---
 
-## ステップ8: USER_REPOSITORY の作業クローン準備
+## Phase 5: ワークスペース準備
 
-`USER_REPOSITORY` が `owner/repository-name`（デフォルト値）の場合はスキップする。
+参照: `Li+bootstrap.md` Phase 5。依存: Phase 2（gh CLI 認証済み）。
 
-それ以外の場合、ワークスペースに対象リポジトリのディレクトリが存在しなければ clone する。既に存在する場合はスキップ（再 clone しない）。
+**5.1. USER_REPOSITORY 作業クローンの準備**
+
+- `USER_REPOSITORY` がデフォルト値 `owner/repository-name` の場合はスキップ
+- `USER_REPOSITORY` が LI_PLUS_REPOSITORY と一致する場合: ローカル clone で `git checkout main` を実行
+- それ以外: ワークスペースに対象リポジトリのディレクトリが存在しなければリポジトリ名で clone。既に存在する場合はスキップ（再 clone しない）
 
 ---
 
-## ステップ9: 完了報告
+## Phase 6: 完了報告
 
-起動完了を報告する。
+参照: `Li+bootstrap.md` Phase 6。依存: すべての先行 Phase。
+
+**6.1. 起動完了を報告する。**
 
 ---
 
 ## 関連ページ
 
 - [B. Configuration](B.-Configuration) — 設定リファレンス
-- [D. Installation](D.-Installation) — Quickstartセットアップ手順
+- [D. Installation](D.-Installation) — Quickstart セットアップ手順
 - [6. Adapter](6.-Adapter) — アダプターレイヤー仕様書
 
 ---


### PR DESCRIPTION
## 目的

docs/C.-Bootstrap.md の見出し構造を、権威ソースである `Li+bootstrap.md` の Phase 1-6 構造に整合させる。旧 Step 1-9 は Li+bootstrap.md の章立てとずれており、「docs = source = test」原則に反していた。

## 変更内容

docs/C.-Bootstrap.md を Phase 1-6 構造へ全面書き換え。各 Phase 見出しに Li+bootstrap.md の参照を明記し、Phase 内のサブ項目 (1.1 / 2.3 / 3.2 / 4c.2 / 4x.1 等) も Li+bootstrap.md をミラーする。

### Phase 再編マップ

| 旧 Step | 新 Phase | 内容 |
|---------|---------|------|
| Step 1 + 2 | Phase 1 | 環境検出 + chmod 600 |
| Step 4 + 5 + 3 | Phase 2 | gh CLI + GH_TOKEN + 言語契約 + webhook 配信モード |
| Step 6 | Phase 3 | LI_PLUS_CHANNEL / LI_PLUS_MODE 解決 |
| Step 7 | Phase 4 | ランタイム分岐 (4c claude / 4x codex)、adapter + rules + skills + hooks 生成 |
| Step 8 | Phase 5 | USER_REPOSITORY clone |
| Step 9 | Phase 6 | 完了報告 |

### 旧ファイル名参照

`Li+core.md` / `Li+github.md` / `Li+issues.md` / `li-plus-issues` skill などの旧名参照は、書き換え後の docs/C.-Bootstrap.md には存在しないことを grep で確認済み。現行の `rules/<layer>/*.md` + `skills/<name>/SKILL.md` 命名に沿った記述に統一。

### 権威ソース優先の調整点

skills/ 階層について、docs/6.-Adapter.md は `<layer>/<name>/` subdir 記述を持つが、Li+bootstrap.md Phase 4c.3 は `flat, no subdirectories` と明言している。現状の skills/ 実装も flat (evolution- / model- / operations- / task- 接頭辞の命名規約でレイヤー属性を表現) であり、docs/C は Li+bootstrap.md を正として flat 記述に揃えた。docs/6.-Adapter.md の差異は本 PR のスコープ外。

Closes #1148, Refs #1140