### PR TITLE
docs(mcp_hook): document v0.11.3 decision-JSON wrap as precondition (patch)

### DIFF
--- a/adapter/claude/hooks-settings.md
+++ b/adapter/claude/hooks-settings.md
@@ -131,7 +131,14 @@ This is **opt-in only**:
 Preconditions:
 
 1. `mcp__github-webhook-mcp` is connected as an MCP server in the workspace.
-2. `Li+config.md` contains `LI_PLUS_WEBHOOK_DELIVERY=mcp_hook` so that the bash
+2. `github-webhook-mcp >= v0.11.3`. Earlier versions return generic JSON
+   (`{pending_count, types, latest_received_at}`) which Claude Code parses
+   successfully but discards because it does not match any UserPromptSubmit
+   decision schema, so the hook output never reaches the AI prompt context.
+   v0.11.3 wraps `get_pending_status` results into the canonical decision JSON
+   shape (`hookSpecificOutput.hookEventName="UserPromptSubmit"` plus a natural
+   language summary in `additionalContext`) on the local bridge side.
+3. `Li+config.md` contains `LI_PLUS_WEBHOOK_DELIVERY=mcp_hook` so that the bash
    hook suppresses its reminder text (the `mcp_tool` hook now covers that
    responsibility).
 
@@ -161,7 +168,12 @@ to the existing `UserPromptSubmit` array:
 }
 ```
 
-The `mcp_tool` hook output is injected into the prompt context the same way
-that a Claude-issued tool call result would be, so the foreground intake skill
-treats it identically to the polled path. Relevance judgment and destructive
-consume rules remain governed by `skills/operations-foreground-webhook-intake/SKILL.md`.
+The `mcp_tool` hook output is injected into the prompt context only when the
+tool returns a value that matches a Claude Code hook decision JSON schema
+(see https://code.claude.com/docs/en/hooks). Generic JSON parses successfully
+but is silently discarded; the decision shape is the only path. With
+`github-webhook-mcp >= v0.11.3` the local bridge wraps `get_pending_status`
+into the UserPromptSubmit decision shape automatically, so the foreground
+intake skill sees the result identically to the polled path. Relevance
+judgment and destructive consume rules remain governed by
+`skills/operations-foreground-webhook-intake/SKILL.md`.

--- a/docs/B.-Configuration.md
+++ b/docs/B.-Configuration.md
@@ -101,13 +101,17 @@ webhook 通知がセッションへ届く方法を指定します。`mcp__github
 |----|------|
 | 未設定 / `poll` | 毎ターン開始時に on-user-prompt hook がポーリングリマインダーを出力する（既定、後方互換） |
 | `channel` | MCP channel がリアルタイムにイベントを配信するため、hook のポーリングリマインダーをスキップする |
-| `mcp_hook` | UserPromptSubmit に追加した `type: "mcp_tool"` hook が `mcp__github-webhook-mcp__get_pending_status` を直接呼び出し、結果を prompt context に注入する。bash hook のポーリングリマインダーはスキップされる |
+| `mcp_hook` | UserPromptSubmit に追加した `type: "mcp_tool"` hook が `mcp__github-webhook-mcp__get_pending_status` を直接呼び出し、結果を prompt context に注入する。bash hook のポーリングリマインダーはスキップされる（`github-webhook-mcp >= v0.11.3` が前提）|
 
 注意:
 
 - 値を切り替えても webhook 通知の前景判定ルールは変わりません。transport（呼び出し主体）が変わるだけです
 - この設定は on-user-prompt hook が実行時に Li+config.md から読み取ります。bootstrap での追加アクションは不要です
-- `mcp_hook` は opt-in 経路です。前提条件として `github-webhook-mcp` が MCP サーバーとして接続済みであり、`{workspace_root}/.claude/settings.json` の `UserPromptSubmit` 配列に `type: "mcp_tool"` エントリを手動で追加する必要があります（具体的な JSON は `adapter/claude/hooks-settings.md` の "Optional: mcp_tool delivery" セクション参照）。Li+ は既存の settings.json を上書きしないため、移行は人間判断で実施します
+- `mcp_hook` は opt-in 経路です。前提条件として:
+  - `github-webhook-mcp` が MCP サーバーとして接続済みであること
+  - `github-webhook-mcp >= v0.11.3` であること（`get_pending_status` の戻り値を Claude Code UserPromptSubmit hook decision JSON shape にラップする bridge 側の対応が必要。それ以前のバージョンでは hook 戻り値が AI 文脈に注入されない）
+  - `{workspace_root}/.claude/settings.json` の `UserPromptSubmit` 配列に `type: "mcp_tool"` エントリを手動で追加すること（具体的な JSON は `adapter/claude/hooks-settings.md` の "Optional: mcp_tool delivery" セクション参照）
+  - Li+ は既存の settings.json を上書きしないため、移行は人間判断で実施します
 
 ### LI_PLUS_WEBHOOK_STATE_DIR
 

--- a/skills/operations-foreground-webhook-intake/SKILL.md
+++ b/skills/operations-foreground-webhook-intake/SKILL.md
@@ -25,6 +25,11 @@ delivery mode interaction (LI_PLUS_WEBHOOK_DELIVERY):
                    and injects the result into prompt context. The AI does not
                    issue the call itself; foreground handling reads the injected
                    status as if it had been polled.
+                   Precondition: github-webhook-mcp >= v0.11.3 (earlier versions
+                   return generic JSON that Claude Code silently discards because
+                   it does not match a hook decision schema; v0.11.3 wraps the
+                   result in UserPromptSubmit decision shape on the local bridge
+                   side).
   source priority above is unchanged across modes; only the *who initiates the
   call* axis differs. Relevance judgment and destructive consume rules apply
   identically.


### PR DESCRIPTION
## 概要

`LI_PLUS_WEBHOOK_DELIVERY=mcp_hook` モードの実機検証で判明した「`mcp_tool` hook 戻り値が AI 文脈に注入されない」事象 (#1167) について、根本原因が `get_pending_status` の戻り値 shape が Claude Code UserPromptSubmit decision schema にマッチしないことだったと判明。

bridge 側修正 (Liplus-Project/github-webhook-mcp#216 → v0.11.3) で `get_pending_status` を canonical decision shape にラップする対応が完了したため、本 PR では Li+ 各 docs に **github-webhook-mcp >= v0.11.3** を `mcp_hook` モードの前提条件として明記する。

## 変更内容

| ファイル | 変更 |
|---|---|
| `adapter/claude/hooks-settings.md` | "Optional: mcp_tool delivery" 節の Preconditions に v0.11.3 要件を追加。末尾段の「injected into the prompt context」記述を decision JSON shape 要件込みに改訂 |
| `docs/B.-Configuration.md` | `LI_PLUS_WEBHOOK_DELIVERY` 表の `mcp_hook` 行に version 注記を追加。注意書きを箇条書き化して前提条件 4 項目を整理 |
| `skills/operations-foreground-webhook-intake/SKILL.md` | `mcp_hook` 行に Precondition 行を追加 |

## 影響範囲

- patch (docs / spec rule の整合のみ。observable な挙動変化なし)
- `docs/C.-Bootstrap.md` / `docs/6.-Adapter.md` / `Li+bootstrap.md` の `mcp_hook` 言及は B への参照のみで本文修正は不要

## 設計上の整理

PR Liplus-Project/liplus-language#1164 本文の「`tool_use` / `tool_result` 往復が消える」と旧 `hooks-settings.md` 末尾の「injected into the prompt context」は、v0.11.3 以降では両立する状態:

- Claude は tool call を発行しない → 往復消失 (#1164 本文の主張)
- Local bridge が decision JSON shape で返す → Claude Code が `additionalContext` を prompt context に注入 (旧 hooks-settings.md の主張)

#1167 当初 body の3案 (A:往復削減のみ / B:AI に届ける / C:upstream 待ち) は実質 B が成立した形。

## 関連

- Closes #1167
- 元 PR (mcp_hook モード導入): #1164 / 元 issue: #1163
- bridge 側修正: Liplus-Project/github-webhook-mcp#216 (v0.11.3 release 済み)
- Claude Code docs literal 出典: https://code.claude.com/docs/en/hooks