### PR TITLE
spec(adapter): split settings.json ownership and ship mcp_tool entry by default (patch)

### DIFF
--- a/Li+bootstrap.md
+++ b/Li+bootstrap.md
@@ -145,18 +145,23 @@ Note: Claude Code's skill discovery does NOT recurse into subdirectories under `
   - adapter/claude/hooks-settings.md — contains the literal `settings.json` JSON block.
   - adapter/claude/hooks/*.sh — hook script bodies as real files (copied verbatim, with
     `{LI_PLUS_TAG}` placeholder replaced by the resolved target tag).
-- If {workspace_root}/.claude/settings.json does not exist:
-  Create it from the JSON code block in adapter/claude/hooks-settings.md.
-  Also create {workspace_root}/.claude/hooks/ and copy all adapter/claude/hooks/*.sh there.
-  SessionStart uses four matchers (startup / resume / clear / compact) so Cold-start Synthesis
-  material is emitted for every session entry point, not only compact.
-- If {workspace_root}/.claude/settings.json exists:
-  - Do not modify settings.json. The workspace owns it; Li+ does not silently rewrite
-    user-added keys (permissions / env / theme / other component hooks).
-  - Check the source tag in existing {workspace_root}/.claude/hooks/*.sh files
+- {workspace_root}/.claude/settings.json is Li+ owned (compare-and-overwrite):
+  - If it does not exist: create it from the JSON code block in adapter/claude/hooks-settings.md.
+    Also create {workspace_root}/.claude/hooks/ and copy all adapter/claude/hooks/*.sh there.
+  - If it exists and content matches the rendered template byte-for-byte: skip
+    (no overwrite, no sensitive-file permission prompt).
+  - If it exists and content differs: overwrite with the rendered template.
+    settings.json is Li+ owned; intentional user customizations
+    (permissions / env / theme / additional hooks / additional MCP entries) belong in
+    {workspace_root}/.claude/settings.local.json which Li+ never touches and
+    Claude Code merges with settings.json at runtime.
+  - SessionStart uses four matchers (startup / resume / clear / compact) so Cold-start Synthesis
+    material is emitted for every session entry point, not only compact.
+- {workspace_root}/.claude/hooks/*.sh tag-tracked regeneration:
+  - Check the source tag in existing files
     (e.g. "# Source: adapter/claude/hooks/on-session-start.sh (build-2026-03-30.14)").
   - If tag matches current target tag: skip (up to date).
-  - If tag differs or is absent: regenerate hook scripts only by copying adapter/claude/hooks/*.sh
+  - If tag differs or is absent: regenerate hook scripts by copying adapter/claude/hooks/*.sh
     and replacing {LI_PLUS_TAG} with the current target tag.
 - on-session-start.sh is the Cold-start Synthesis material emitter. Its stdout is injected into
   the session-opening context (Claude Code SessionStart contract). The hook gathers material

--- a/adapter/claude/CLAUDE.md
+++ b/adapter/claude/CLAUDE.md
@@ -187,8 +187,12 @@ Delivery mode is selected by `LI_PLUS_WEBHOOK_DELIVERY` in `Li+config.md`:
   calls `mcp__github-webhook-mcp__get_pending_status` itself.
 - `channel` — MCP channel pushes events in real time; the bash hook skips the
   reminder.
-- `mcp_hook` — a sibling `type: "mcp_tool"` UserPromptSubmit hook entry calls
-  the MCP tool directly at hook execution time, removing the
-  `tool_use` / `tool_result` round trip. The bash hook skips the reminder.
-  Opt-in: requires `github-webhook-mcp` to be connected as an MCP server and a
-  manual `settings.json` addition documented in `adapter/claude/hooks-settings.md`.
+- `mcp_hook` — the `type: "mcp_tool"` UserPromptSubmit hook entry shipped in the
+  default `settings.json` template (rendered by bootstrap from
+  `adapter/claude/hooks-settings.md`) calls the MCP tool directly at hook
+  execution time, removing the `tool_use` / `tool_result` round trip. The bash
+  hook skips its reminder text. Manual `settings.json` editing is no longer
+  required (legacy opt-in step retired). Webhook context only reaches the AI
+  when `github-webhook-mcp >= v0.11.3` is connected as an MCP server in the
+  host; otherwise the resolver returns `not connected` plain text per turn,
+  harmless but visible.

--- a/adapter/claude/hooks-settings.md
+++ b/adapter/claude/hooks-settings.md
@@ -2,31 +2,50 @@
 
 Layer = L6 Adapter Layer (Claude Code binding)
 Semantic source = adapter/claude/CLAUDE.md trigger contract + L1 Model Layer / L2 Evolution Layer / L3 Task Layer / L4 Operations Layer foreground intake rules.
-This file defines the `hooks` section of `{workspace_root}/.claude/settings.json`.
+This file defines the entire `{workspace_root}/.claude/settings.json` content.
 
 Bootstrap target: runtime=claude only.
 Hook script bodies live as real files under `adapter/claude/hooks/` and are copied
-verbatim into `{workspace_root}/.claude/hooks/` at bootstrap time. Only the
-`settings.json` binding needs markdown-format housing, because existing
-workspace-side `settings.json` may already contain unrelated keys
-(`permissions`, `env`, `theme`, other component hooks) that Li+ must not touch.
+verbatim into `{workspace_root}/.claude/hooks/` at bootstrap time.
+
+## File ownership boundary
+
+`{workspace_root}/.claude/settings.json` = **Li+ owned**. Bootstrap renders it
+from the literal template below.
+
+`{workspace_root}/.claude/settings.local.json` = **user owned**. Li+ never touches
+this file. Anything the workspace owner wants persisted alongside Li+'s wiring —
+`permissions`, `env`, `theme`, additional `command` hooks, additional `mcp_tool`
+hooks for other MCP servers — goes here.
+
+Claude Code reads both files at runtime and merges them, so user keys in
+`settings.local.json` remain effective without entering Li+'s template surface.
+
+**Migration note for workspaces upgraded from earlier Li+ versions:** any
+user-added keys currently sitting in `settings.json` (permissions / env / theme /
+custom hooks / additional `mcp_tool` entries) should be moved to
+`settings.local.json` before the first bootstrap under this rule. Otherwise the
+compare-and-overwrite step (see below) detects content drift and overwrites
+`settings.json` with the Li+ template, dropping the user keys.
 
 ## Bootstrap behavior
 
-- If `{workspace_root}/.claude/settings.json` does not exist: create it from the
-  literal JSON below (initial template; permissions and other keys are added
-  later by the workspace owner).
-- If `{workspace_root}/.claude/settings.json` exists: **do not modify it**. The
-  workspace owns the file once it has been created. Any future change to the
-  hooks structure below must be applied manually by the human, guided by release
-  notes — Li+ will not silently rewrite user settings.
-- Hook script bodies (`hooks/*.sh`) are regenerated on tag mismatch. The
-  `settings.json` structure is stable and is not regenerated.
+- If `{workspace_root}/.claude/settings.json` does **not exist**: create it from
+  the literal JSON below.
+- If `{workspace_root}/.claude/settings.json` **exists and content matches** the
+  rendered template byte-for-byte: skip (no overwrite, no permission prompt).
+- If `{workspace_root}/.claude/settings.json` **exists and content differs**:
+  overwrite with the rendered template. `settings.json` is Li+ owned per the
+  File ownership boundary; intentional user customizations belong in
+  `settings.local.json`.
+- Hook script bodies (`hooks/*.sh`) are regenerated on tag mismatch (per the
+  `# Source: ... ({LI_PLUS_TAG})` comment line).
 
-Structure stability rationale: hook script paths and matcher names below are
-deliberately long-lived — hook logic changes happen inside the script files,
-not in the settings.json wiring. If the wiring ever needs to change, surface
-it through release notes so the human decides when to apply it.
+This compare-and-overwrite rule replaces the previous "do not modify if exists"
+rule. The previous rule prevented Li+ from rolling out hook structure updates
+automatically; the new rule keeps `settings.json` aligned with the template
+release-by-release while sparing the user from sensitive-file permission prompts
+on every bootstrap (only fires when content actually differs).
 
 ## settings.json
 
@@ -41,6 +60,12 @@ Target: `{workspace_root}/.claude/settings.json`
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/on-user-prompt.sh\""
+          },
+          {
+            "type": "mcp_tool",
+            "server": "github-webhook-mcp",
+            "tool": "get_pending_status",
+            "input": {}
           }
         ]
       }
@@ -110,70 +135,34 @@ Real files, copied verbatim into `{workspace_root}/.claude/hooks/` on bootstrap
 Each script carries a `# Source: ... ({LI_PLUS_TAG})` comment line near the top as
 the tag-tracking anchor. Bootstrap's tag-mismatch check reads this line.
 
-## Optional: mcp_tool delivery (manual opt-in)
+## mcp_tool entry behavior
 
-Claude Code v2.1.118 added a `type: "mcp_tool"` hook variant that invokes an MCP
-server tool directly at hook execution time, without going through Claude.
-Workspaces that have `mcp__github-webhook-mcp` connected can opt in to this
-direct delivery path for the webhook intake check, eliminating the
-`tool_use` / `tool_result` round trip that the default reminder text forces.
+The default template includes a `type: "mcp_tool"` UserPromptSubmit hook entry
+that invokes `get_pending_status` on `github-webhook-mcp`. Claude Code v2.1.118+
+parses the tool's text content as JSON; only output matching a Claude Code hook
+decision schema reaches the AI prompt context (docs literal at
+https://code.claude.com/docs/en/hooks).
 
-This is **opt-in only**:
-
-- The default `settings.json` template above is unchanged. It does not assume
-  `github-webhook-mcp` is connected, so it stays safe for every workspace.
-- Existing workspaces are not silently rewritten (see Bootstrap behavior). The
-  human applies the opt-in manually.
-- The bash `on-user-prompt.sh` hook still runs for the Character_Instance
-  re-notify. The `mcp_tool` entry is added as a *sibling* hook in the same
-  `UserPromptSubmit` array, not a replacement.
-
-Preconditions:
+Preconditions for the entry to actually deliver webhook context to the AI:
 
 1. `mcp__github-webhook-mcp` is connected as an MCP server in the workspace.
 2. `github-webhook-mcp >= v0.11.3`. Earlier versions return generic JSON
    (`{pending_count, types, latest_received_at}`) which Claude Code parses
    successfully but discards because it does not match any UserPromptSubmit
-   decision schema, so the hook output never reaches the AI prompt context.
-   v0.11.3 wraps `get_pending_status` results into the canonical decision JSON
-   shape (`hookSpecificOutput.hookEventName="UserPromptSubmit"` plus a natural
-   language summary in `additionalContext`) on the local bridge side.
-3. `Li+config.md` contains `LI_PLUS_WEBHOOK_DELIVERY=mcp_hook` so that the bash
-   hook suppresses its reminder text (the `mcp_tool` hook now covers that
-   responsibility).
+   decision schema. v0.11.3 wraps `get_pending_status` results into the
+   canonical decision shape (`hookSpecificOutput.hookEventName="UserPromptSubmit"`
+   plus a natural language summary in `additionalContext`) on the local bridge
+   side, so the wrapped output reaches the AI prompt context.
 
-Manual edit to `{workspace_root}/.claude/settings.json`: add the second entry
-to the existing `UserPromptSubmit` array:
+`Li+config.md`'s `LI_PLUS_WEBHOOK_DELIVERY` setting controls the *bash hook's*
+reminder text behavior (poll / channel / mcp_hook) independently. The
+`mcp_tool` entry itself fires unconditionally; setting
+`LI_PLUS_WEBHOOK_DELIVERY=mcp_hook` suppresses the bash hook's reminder text so
+the wrap delivery is the single source of webhook context.
 
-```json
-{
-  "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/on-user-prompt.sh\""
-          },
-          {
-            "type": "mcp_tool",
-            "server": "github-webhook-mcp",
-            "tool": "get_pending_status",
-            "input": {}
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-The `mcp_tool` hook output is injected into the prompt context only when the
-tool returns a value that matches a Claude Code hook decision JSON schema
-(see https://code.claude.com/docs/en/hooks). Generic JSON parses successfully
-but is silently discarded; the decision shape is the only path. With
-`github-webhook-mcp >= v0.11.3` the local bridge wraps `get_pending_status`
-into the UserPromptSubmit decision shape automatically, so the foreground
-intake skill sees the result identically to the polled path. Relevance
-judgment and destructive consume rules remain governed by
-`skills/operations-foreground-webhook-intake/SKILL.md`.
+If `github-webhook-mcp` is **not connected**: Claude Code's mcp_tool resolver
+returns a `not connected` error per turn. The error is surfaced as plain text
+to the AI but carries no actionable webhook payload. Workspaces that do not use
+the webhook intake flow at all can leave the entry inert (the error is harmless
+beyond the per-turn noise) or remove it knowing the next bootstrap will
+restore it from the template.

--- a/docs/B.-Configuration.md
+++ b/docs/B.-Configuration.md
@@ -101,17 +101,23 @@ webhook 通知がセッションへ届く方法を指定します。`mcp__github
 |----|------|
 | 未設定 / `poll` | 毎ターン開始時に on-user-prompt hook がポーリングリマインダーを出力する（既定、後方互換） |
 | `channel` | MCP channel がリアルタイムにイベントを配信するため、hook のポーリングリマインダーをスキップする |
-| `mcp_hook` | UserPromptSubmit に追加した `type: "mcp_tool"` hook が `mcp__github-webhook-mcp__get_pending_status` を直接呼び出し、結果を prompt context に注入する。bash hook のポーリングリマインダーはスキップされる（`github-webhook-mcp >= v0.11.3` が前提）|
+| `mcp_hook` | UserPromptSubmit の `type: "mcp_tool"` hook が `mcp__github-webhook-mcp__get_pending_status` を直接呼び出し、結果を prompt context に注入する。bash hook のポーリングリマインダーはスキップされる（`github-webhook-mcp >= v0.11.3` が前提） |
 
 注意:
 
 - 値を切り替えても webhook 通知の前景判定ルールは変わりません。transport（呼び出し主体）が変わるだけです
 - この設定は on-user-prompt hook が実行時に Li+config.md から読み取ります。bootstrap での追加アクションは不要です
-- `mcp_hook` は opt-in 経路です。前提条件として:
-  - `github-webhook-mcp` が MCP サーバーとして接続済みであること
+- `mcp_tool` の hook entry は `adapter/claude/hooks-settings.md` の default テンプレートに含まれており、bootstrap によって `.claude/settings.json` に自動配置されます。**手動追加は不要**になりました（旧仕様では opt-in に手動編集が必要でした）
+- 配信が実際に AI 文脈へ届く前提条件:
+  - `mcp__github-webhook-mcp` が MCP サーバーとして接続済みであること（CLI なら `~/.claude.json` / `.mcp.json` / `claude mcp add`、Desktop なら `claude_desktop_config.json`）
   - `github-webhook-mcp >= v0.11.3` であること（`get_pending_status` の戻り値を Claude Code UserPromptSubmit hook decision JSON shape にラップする bridge 側の対応が必要。それ以前のバージョンでは hook 戻り値が AI 文脈に注入されない）
-  - `{workspace_root}/.claude/settings.json` の `UserPromptSubmit` 配列に `type: "mcp_tool"` エントリを手動で追加すること（具体的な JSON は `adapter/claude/hooks-settings.md` の "Optional: mcp_tool delivery" セクション参照）
-  - Li+ は既存の settings.json を上書きしないため、移行は人間判断で実施します
+- MCP サーバー未接続の場合、Claude Code の `mcp_tool` resolver が毎ターン `not connected` テキストを context に出します。挙動上の害はありませんが、webhook 通知を使わないユーザーは設定ノイズとして見えます
+
+### settings.json と settings.local.json の所有境界 (build-2026-04-25 以降)
+
+- `.claude/settings.json` = **Li+ 所有**。bootstrap が `adapter/claude/hooks-settings.md` の literal を render し、内容差分があれば上書きします（compare-and-overwrite。同一なら sensitive-file プロンプトも出ません）
+- `.claude/settings.local.json` = **ユーザー所有**。Li+ は一切触りません。`permissions` / `env` / `theme` / 独自 hook / 追加 MCP entry はここに置きます。Claude Code が runtime で両ファイルを merge します
+- **既存 workspace の移行注意**: 既に `.claude/settings.json` に user-added キー（permissions / env / theme / 独自 hook / 追加 mcp_tool entry）を入れている環境は、本仕様適用前に `settings.local.json` へ移してください。compare-and-overwrite が差分を検出すると Li+ template で上書きされ、user-added キーが失われます
 
 ### LI_PLUS_WEBHOOK_STATE_DIR
 

--- a/skills/operations-foreground-webhook-intake/SKILL.md
+++ b/skills/operations-foreground-webhook-intake/SKILL.md
@@ -20,16 +20,23 @@ source priority:
 delivery mode interaction (LI_PLUS_WEBHOOK_DELIVERY):
   poll (default) = each user turn, the AI calls mcp__github-webhook-mcp__get_pending_status.
   channel        = MCP channel pushes events; AI does not poll, intake reads the channel surface.
-  mcp_hook       = a type=mcp_tool UserPromptSubmit hook entry invokes
-                   mcp__github-webhook-mcp__get_pending_status directly at hook time
-                   and injects the result into prompt context. The AI does not
-                   issue the call itself; foreground handling reads the injected
-                   status as if it had been polled.
-                   Precondition: github-webhook-mcp >= v0.11.3 (earlier versions
-                   return generic JSON that Claude Code silently discards because
-                   it does not match a hook decision schema; v0.11.3 wraps the
-                   result in UserPromptSubmit decision shape on the local bridge
-                   side).
+  mcp_hook       = the type=mcp_tool UserPromptSubmit hook entry shipped in the
+                   default settings.json template invokes
+                   mcp__github-webhook-mcp__get_pending_status directly at hook
+                   time and injects the result into prompt context. The AI does
+                   not issue the call itself; foreground handling reads the
+                   injected status as if it had been polled.
+                   Preconditions:
+                   - github-webhook-mcp >= v0.11.3 (earlier versions return
+                     generic JSON that Claude Code silently discards because it
+                     does not match a hook decision schema; v0.11.3 wraps the
+                     result in UserPromptSubmit decision shape on the local
+                     bridge side).
+                   - github-webhook-mcp registered as an MCP server in the host
+                     (CLI: .mcp.json / ~/.claude.json / claude mcp add;
+                     Desktop: claude_desktop_config.json). When unregistered,
+                     the mcp_tool resolver returns plain `not connected` text
+                     per turn — harmless but visible noise.
   source priority above is unchanged across modes; only the *who initiates the
   call* axis differs. Relevance judgment and destructive consume rules apply
   identically.


### PR DESCRIPTION
## 概要

`adapter/claude/hooks-settings.md` の旧ルール「`.claude/settings.json` が存在する場合は Li+ が一切触らない」を見直し、ファイル単位で所有権を分割。

- `.claude/settings.json` = **Li+ 所有** (compare-and-overwrite で内容差分時のみ上書き、no-diff なら sensitive-file プロンプトも出ない)
- `.claude/settings.local.json` = **ユーザー所有** (Li+ 不可侵。permissions / env / theme / 独自 hook / 追加 mcp_tool entry はここ)
- Claude Code が runtime で両ファイルを merge

これに合わせて、PR #1164 で opt-in 経路として導入した `type: \"mcp_tool\"` UserPromptSubmit hook entry を **default テンプレートに昇格**。手動 `settings.json` 編集が不要になる。

## 設計判断の経緯

\`mcp_tool\` entry の render 戦略について以下 3 案を検討:

| 案 | 内容 | 採否 |
|---|---|---|
| (i) 常に含める | 未接続環境では Claude Code resolver が \`not connected\` plain text を毎ターン context に出すが、挙動上の害なし | **採用** |
| (ii) bootstrap が MCP 登録源を読んで条件 render | settings.json はクリーンだが、MCP 後付け登録時に1セッション stale + 次 bootstrap で再書込み摩擦。bootstrap が CLI/Desktop で異なる platform 別 path 解決ロジックを抱える | 不採用 |
| (iii) `LI_PLUS_WEBHOOK_DELIVERY` config に紐付け | config 駆動で明示的だが mid-session 切替時の stale が残る | 不採用 |

採用根拠 = **bootstrap を MCP enumeration から decoupled に保つ + mid-session MCP 追加で即動く + noise は一行 plain text で実害なし**。

## 変更ファイル

- \`Li+bootstrap.md\` Phase 4c.4: compare-and-overwrite ロジックに改訂
- \`adapter/claude/hooks-settings.md\`: default JSON に \`mcp_tool\` entry 追加 + File ownership boundary 節 + 移行注意 + mcp_tool entry behavior 節
- \`adapter/claude/CLAUDE.md\`: Optional Webhook Notification Flow 節を default 化に合わせて更新
- \`docs/B.-Configuration.md\`: \`LI_PLUS_WEBHOOK_DELIVERY\` 注記更新 + settings.json/local.json 所有境界節を追加
- \`skills/operations-foreground-webhook-intake/SKILL.md\`: \`mcp_hook\` 行から「manual addition」記述を削除

## 既存 workspace への影響 (移行注意)

既に \`.claude/settings.json\` に user-added キー (permissions / env / theme / 独自 hook / 追加 \`mcp_tool\` entry) を入れている環境は、本仕様適用前に \`settings.local.json\` へ移してください。compare-and-overwrite が差分を検出すると Li+ template で上書きされ、user-added キーが失われます。

本セッション workspace (\`C:/Users/smile/Code\`) では既に分離済みであることを実機確認済み (settings.json top-level keys = [\"hooks\"] のみ)。

## バージョン

minor (large + user-observable structural change per \`rules/operations/release-version.md\`)

## 関連

- Closes #1165
- 元 PR (mcp_hook delivery 導入時に opt-in 設計): #1164
- 直近 release: build-2026-04-25.2 (#1168 マージで CD auto-tag)