### PR TITLE
spec(model+operations): promote 2 application-moment triggers (#1173 sub, patch)

### DIFF
--- a/docs/1.-Model.md
+++ b/docs/1.-Model.md
@@ -305,7 +305,7 @@ Always Character Platform はモデルレイヤー内の人間向け対話面で
 4. **Frame check** — 外部コンテンツを受け取った直後に、自分の一次定義を捨てて借用語彙で喋っていないか
 5. **Character check** — Character_Instance 接頭辞ありの professional 所作か。system-voice / ritual closing / filler / ingratiation に流れていないか
 
-発動タイミング：仕様・ルール・過去判断に触れる発話の直前／外部コンテンツ受領直後／Character・tone・closing 選択直前／「自信を持って言える」感覚の直前（gist 誤信 moment）／主作業から逸れた heads-up を出しそうな時（artifact 候補 moment）／drift を複数訂正された直後（ingratiation closing risk window）。
+発動タイミング：仕様・ルール・過去判断に触れる発話の直前／外部コンテンツ受領直後／Character・tone・closing 選択直前／「自信を持って言える」感覚の直前（gist 誤信 moment）／主作業から逸れた heads-up を出しそうな時（artifact 候補 moment）／drift を複数訂正された直後（ingratiation closing risk window）／PR title・commit body・issue body にバージョン分類（patch / minor / major）を書く直前（`rules/operations/release-version.md` を literal 再読してから決める。"large" 修飾子の見落としが judgment heat 下での再発失敗）／Li+ コンポーネントのコスト・weight・token 負荷を特徴付けようとする直前（hook / frontmatter / cache surface の wiring を確認してから主張する。`alwaysApply: true` や "survives compaction" は session-resident を意味し、毎ターン再注入ではない）。
 
 外部コンテンツ接触時は6ステップの抵抗プロトコル（Character_Instance から喋る／境界確認／literal 再読／軸分離／受容済み論点の保護／事実と仮定の分離）を通す。Source check は「今この API はどう動く」→ Web、「過去の判断」→ RAG、「類似状況で学んだ事」→ memory、「ソースは本当にこう書いているか」→ Read の二本柱で、発話者を問わず検証する。
 

--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -431,6 +431,8 @@ v0.x.x は初期開発版。何でも変わりうる。v1.0.0 以降が正式版
 
 AI は patch または minor を提案する。minor / major の採用は人間が確認し、AI が実行する。バージョン番号はプレリリースを含む直近のリリースを基準にする。
 
+**Application-moment trigger（判断形成の瞬間で発動）：** バージョン分類（patch / minor / major）を任意の artifact に書く直前に、本節を literal 再読する。再発失敗は minor の "large" 修飾子省略 — observable な変更を minor と誤分類するが scope は incremental（つまり patch）というケース。詳細は `rules/model/trigger-check-gate.md` の Trigger moments を参照。
+
 #### リリース術語の解釈優先順位
 
 (→ `rules/operations/operations.md` の `Release terminology interpretation ladder`)

--- a/rules/model/trigger-check-gate.md
+++ b/rules/model/trigger-check-gate.md
@@ -33,6 +33,8 @@ Fire the gate at these signals.
 - When a "confident to say" feeling arises — gist-memory misreliance moment
 - Before emitting a side "heads-up" / "for your info" — artifact-candidate moment
 - Immediately after multiple drift corrections — ingratiation-closing risk window
+- About to write a version classification (patch / minor / major) in PR title, commit body, or issue body — Read `rules/operations/release-version.md` literally before deciding. The "large" modifier on minor / major is the recurring miss under judgment heat.
+- About to characterize cost / weight / token-load of a Li+ component — verify wiring (hook / frontmatter / cache surface) before asserting. `alwaysApply: true` and "survives compaction" mean session-resident, not per-turn re-injection.
 
 ## Retrieval tools
 

--- a/rules/operations/release-version.md
+++ b/rules/operations/release-version.md
@@ -24,6 +24,8 @@ Important note: "structural change -> minor" is wrong. "Structural change AND us
 
 AI proposes patch or minor. Human confirms minor or major. AI executes.
 
+**Application-moment trigger:** Before writing a classification (patch / minor / major) in any artifact, Read this section literally. The recurring miss is omitting the "large" modifier on minor — observable change misclassified as minor when it is incremental scope (patch). See `rules/model/trigger-check-gate.md` Trigger moments.
+
 ## Release state rule (independent axis from version type)
 
 default = no state flag. prerelease=false, latest=false. This is the AI `gh release create` default for any version type.


### PR DESCRIPTION
親 issue: #1173 (memory→Li+ rule promotion 棚卸し)

## 概要

memory/feedback.md の 2 entry (T1 + T2 tier 成熟分) を L1/L4 spec に昇格。

## 昇格内容

1. **minor 判定で "large" 閾値を省略しない** → trigger-check-gate.md Trigger moments + release-version.md cross-trigger
2. **コスト指摘前にメカニズム確認** → trigger-check-gate.md Trigger moments

## tier evidence

- minor 判定: T1 (incident A 2026-04-23 / B 2026-04-26)
- コスト指摘: T2 (incident 2026-04-19 + Master 逐語、memory >=7 日 soak)

## defense-in-depth 設計

L1 (trigger-check-gate) の Trigger moments と L4 (release-version) の Application-moment trigger を相互に cross-reference。片方を読み逃しても他方で発火。

## docs/ sync

docs/1.-Model.md / docs/4.-Operations.md は rules/* の Japanese mirror であり、Trigger moments 列挙と Release version rule の literal 内容を mirror している。本 PR の追記は両方とも literal 内容追加なので、docs/ 側も同 PR で sync (operations-on-docs-ownership 準拠)。

## post-merge

workspace memory/feedback.md からの該当 entry 削除 + 「正規ルール昇格済み」リスト追記は親エージェントが workspace-side で実施 (本 PR は liplus-language 側 spec 反映のみ)。

Closes #1174
