### PR TITLE
spec(operations): autonomous run stop condition (#1173 sub, patch)

### DIFF
--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -73,6 +73,29 @@ L3 タスクレイヤーとの境界：issue Format、Issue Maturity、Sub-issue
 
 ---
 
+## 自走 (autonomous run) の停止条件
+
+(→ `rules/operations/operations.md` の `## Autonomous Run Stop Condition`)
+
+AI が人間の介在なしに走る場合（夜間、`semi_auto` / `auto` モードで deploy まで到達するケース）、「deploy 成功」は停止条件にならない。静的検証（TS check、unit test、CI）は runtime 正しさを保証しない。subrequest 上限、IPC、rate limit、schema migration の副作用などの runtime 経路は、静的検証とは別軸に存在する。
+
+production に到達する自走では、以下を最終ステップとして必ず実行する：
+
+- deploy 完了後、production log を最低 5 分観測する
+- cron 駆動のワークでは、「deploy 完了」とは「deploy コマンドが exit 0 で終わった時点」ではなく「deploy 後の最初の cron 周回が log で観測できた時点」を指す
+- ホストの logs surface（ブラウザの dashboard、`wrangler tail`、同等の CLI）を使う。事前付与済みのブラウザ権限は、人間監視下のセッションのために留保するのではなく、自走中に積極的に活用する
+
+アンチパターン：「Master が朝に確認するから、自走の post-deploy 観測は不要」。検出タイミングの利得（夜間検出 vs 朝検出）こそ自走が提供すべき価値であり、観測を省略するとその価値を放棄することになる。
+
+停止条件が誤適用されている兆候：
+
+- deploy 成功の瞬間に走完サマリを書き始めている
+- 自走自身が verify する前に「人間が見てくれる」を理由にしている
+- dashboard / log アクセス権限が事前付与されているのに自走中に未使用
+- 走完報告が cron interval 1 周分より短い時間で提出されている
+
+---
+
 ## 責務
 
 条件→行動。省略不可。AI が条件を判断し、条件に合致したら必ず実行する。

--- a/rules/operations/operations.md
+++ b/rules/operations/operations.md
@@ -80,6 +80,23 @@ PR auto-merge policy is mode-specific:
   auto mode = repo-level "Allow auto-merge" is INTENTIONALLY disabled. `gh pr merge --auto` being rejected is by design, not a config gap. Parent AI performs self-review then manual `gh pr merge {pr} --squash`.
 mark_processed is mandatory for every consumed webhook event. Omission causes backlog accumulation.
 
+## Autonomous Run Stop Condition
+
+When AI runs without human at the wheel (overnight, semi_auto/auto execution mode reaching deploy), "deploy succeeded" is not the stop condition. Static checks (TS check, unit tests, CI) cannot guarantee runtime correctness — subrequest limits, IPC, rate limits, schema migration side effects, and similar runtime paths sit on a different axis from static verification.
+
+Required final step in any autonomous run that reaches production:
+- Observe production logs for at least ~5 minutes after deploy completes.
+- For cron-triggered work, "deploy complete" means "first cron iteration after deploy observed in logs", not "deploy command exited 0".
+- Use the host's logs surface (browser dashboard, `wrangler tail`, equivalent CLI). Pre-granted browser access is to be actively used during autonomous runs, not reserved for human-supervised sessions.
+
+Anti-pattern: "Master will check in the morning, so my post-deploy observation is unnecessary." Detection-time gain (overnight catch vs morning catch) is the value autonomous runs are supposed to deliver; skipping observation forfeits it.
+
+Detection signs that the stop condition is being misapplied:
+- Writing the run-completion summary the moment deploy succeeds.
+- Reasoning "the human will see it" before the run actually verifies.
+- Pre-granted dashboard / log access exists but is unused during the run.
+- Run-completion report is filed in less time than one cron interval.
+
 ## Operations Label
 
 ### Rules


### PR DESCRIPTION
親 issue: #1173 (memory→Li+ rule promotion 棚卸し)、L4 バケット (c)、L4 系最後の PR。

## 概要

memory/feedback.md の 1 entry を `rules/operations/operations.md` に新節として昇格。

## 設計

operations.md の Operations Rules / Operations Label の間に独立した ## section を挿入。autonomous run の停止条件が既存ルール (PR auto-merge policy 等) とは別軸 (deploy 後の runtime verification) なので、Operations Rules 内の bullet 追加ではなく独立節として位置付け。

## incident 連環

github-rag-mcp #131 hotfix の遠因。夜間自走で W4 (#128 / PR #129) merge → CI pass → deploy 成功で停止 → :45 cron で `pollWiki` "Too many subrequests" 多発 → Master 起床まで未検出。本 spec が当時あれば deploy 後 5 分の dashboard 一瞥で検出可能だった。

## post-merge

workspace memory/feedback.md からの entry 削除 + 「正規ルール昇格済み」リスト追記は親エージェントが workspace-side で実施。

Closes #1180
