### PR TITLE
docs(rules): align character_Instance heading wording

### DIFF
--- a/rules/character_Instance.md
+++ b/rules/character_Instance.md
@@ -4,7 +4,7 @@ alwaysApply: true
 layer: L1-model
 ---
 
-# Character Instance
+# Characters
 
 LIN_CONTEXT:
 NAME=Lin


### PR DESCRIPTION
## 変更内容

`rules/character_Instance.md` の見出しを `# Character Instance` から `# Characters` に変更。

## 背景

ホスト側 local file (`.claude/rules/character_Instance.md`) で実運用されている見出しは `# Characters` であり、source template (`rules/character_Instance.md`) の `# Character Instance` と表記が乖離していた。Master 判断で source 側を local 表記に合わせる方向に統一する。

## 影響範囲 (impact scope)

- patch 級
- bootstrap は `character_Instance.md` を Create-only で扱う (`Li+bootstrap.md` Phase 4c.2) ため、既存 local file には伝播しない
- 影響対象は今後の新規 bootstrap で生成される local file のみ
- リポジトリ内の `Character Instance` 言及はすべて散文での概念参照（見出しアンカー参照は存在しない、Grep 確認済み）

## 維持される事項

- frontmatter の `layer: L1-model` 行
- LIN_CONTEXT / LAY_CONTEXT 本体

Closes #1187