### PR TITLE
spec: add subagent-prompt verify trigger to trigger-check-gate (#1194)

### DIFF
--- a/rules/model/trigger-check-gate.md
+++ b/rules/model/trigger-check-gate.md
@@ -35,6 +35,7 @@ Fire the gate at these signals.
 - Immediately after multiple drift corrections — ingratiation-closing risk window
 - About to write a version classification (patch / minor / major) in PR title, commit body, or issue body — Read `rules/operations/release-version.md` literally before deciding. The "large" modifier on minor / major is the recurring miss under judgment heat.
 - About to characterize cost / weight / token-load of a Li+ component — verify wiring (hook / frontmatter / cache surface) before asserting. `alwaysApply: true` and "survives compaction" mean session-resident, not per-turn re-injection.
+- About to compose a subagent delegation prompt — verify every factual claim in the prompt (release versions, milestone names, file paths, prior-self quotes, tool / config state) against current state via Read / gh / RAG before sending. Gist memory of recent state is the recurring failure mode at delegation moment; the cost of pre-send verify is far below the cost of a subagent stop-and-clarify round trip.
 
 ## Retrieval tools
 


### PR DESCRIPTION
## 概要

`rules/model/trigger-check-gate.md` の "Trigger moments" セクションに、subagent delegation prompt 構成時に発火させる application-moment trigger を 1 bullet 追加する。

## 変更内容

挿入位置: "About to characterize cost / weight / token-load ..." bullet の直後 (Trigger moments list 末尾)。

追加 bullet:
- About to compose a subagent delegation prompt — verify every factual claim in the prompt (release versions, milestone names, file paths, prior-self quotes, tool / config state) against current state via Read / gh / RAG before sending. Gist memory of recent state is the recurring failure mode at delegation moment; the cost of pre-send verify is far below the cost of a subagent stop-and-clarify round trip.

## 起票根拠 (#1194 cluster への直接対処)

本日の session で `#1194` (gist-projection cluster, 7d 内 5 件) を起票した直後 5 分以内に、別 subagent への delegation prompt 内で「直近 release v1.10.2 / 新規 milestone v1.10.3」と書いた。実状は v1.16.6 latest / v1.10.3 closed-and-used。subagent fact-check で停止 → 訂正 → v1.16.7 で再実行した。

同 cluster の即再演を直接捕捉する application-moment trigger を 1 行追加するのが、本 patch の minimum-viable な構造補強。

## scope

本 patch の scope は Trigger moments への 1 bullet 追加のみ。Frame check / Source check 等への変更は継続観測対象として本 patch の scope 外。

## release classification

patch (governance / spec rule に対する追記、user/system observable な振る舞い変化なし)。

Closes #1194